### PR TITLE
Add small-time

### DIFF
--- a/recipes/small-time/recipe.yaml
+++ b/recipes/small-time/recipe.yaml
@@ -24,6 +24,11 @@ tests:
       - if: unix
         then:
           - mojo test test/test_small_time.mojo
+    files:
+      recipe:
+        - test_small_time.mojo
+        - test_time_delta.mojo
+        - test_time_zone.mojo
 
 about:
   homepage: https://github.com/thatstoasty/small-time

--- a/recipes/small-time/recipe.yaml
+++ b/recipes/small-time/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  version: "0.0.1"
+
+package:
+  name: "mist"
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/thatstoasty/small-time.git
+    rev: 67fae584d1d4742a9421575c8a59d34cb84c14a3
+
+build:
+  number: 0
+  script:
+    - mojo package src/small-time -o ${{ PREFIX }}/lib/mojo/small-time.mojopkg
+requirements:
+  host:
+    - max =24.6
+  run:
+    - ${{ pin_compatible('max') }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo test test/test_small_time.mojo
+
+about:
+  homepage: https://github.com/thatstoasty/small-time
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
+  # See https://spdx.org/licenses/
+  license: Apache 2.0
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  license_file: LICENSE
+  summary: Datetime library forked from morrow.mojo
+  repository: https://github.com/thatstoasty/small-time
+
+extra:
+  maintainers:
+    - thatstoasty

--- a/recipes/small-time/recipe.yaml
+++ b/recipes/small-time/recipe.yaml
@@ -30,7 +30,7 @@ about:
   # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
   # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
   # See https://spdx.org/licenses/
-  license: Apache 2.0
+  license: Apache-2.0
   # It is strongly encouraged to include a license file in the package,
   # (even if the license doesn't require it) using the license_file entry.
   # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file


### PR DESCRIPTION
Add @thatstoasty's small-time, which is a dependency of lightbug_http

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
