### PR TITLE
Fix mojo-websockets version to match the right one in the repo

### DIFF
--- a/recipes/websockets/recipe.yaml
+++ b/recipes/websockets/recipe.yaml
@@ -19,7 +19,7 @@ requirements:
     - max == 25.1
   run:
     - ${{ pin_compatible('max') }}
-    
+
 tests:
   - script:
       - if: unix

--- a/recipes/websockets/recipe.yaml
+++ b/recipes/websockets/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.1"
+  version: "0.1.2"
 
 package:
   name: "websockets"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/msaelices/mojo-websockets.git
-    rev: 30f0927ce27cde04cf25304b6d449f36d20281a1
+    rev: 86ff5744e437fe2203ed8a1be5db62964f084e02
 
 build:
   number: 0
@@ -19,18 +19,6 @@ requirements:
     - max == 25.1
   run:
     - ${{ pin_compatible('max') }}
-
-tests:
-  - script:
-      - if: unix
-        then:
-          - mojo test tests/test_bytes.mojo
-    requirements:
-      run:
-        - max=25.1
-    files:
-      recipe:
-        - tests/test_bytes.mojo
 
 about:
   homepage: https://github.com/msaelices/mojo-websockets

--- a/recipes/websockets/recipe.yaml
+++ b/recipes/websockets/recipe.yaml
@@ -19,6 +19,18 @@ requirements:
     - max == 25.1
   run:
     - ${{ pin_compatible('max') }}
+    
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo test tests/test_bytes.mojo
+    requirements:
+      run:
+        - max=25.1
+    files:
+      recipe:
+        - tests/test_bytes.mojo
 
 about:
   homepage: https://github.com/msaelices/mojo-websockets


### PR DESCRIPTION
**Checklist**
- [X] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [X] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [X] Set the build number to `0` (for new packages, or if the version changed).
- [X] Bumped the build number (if the version is unchanged).
