### PR TITLE
chore: add linux-aarch64 support for extramojo

### DIFF
--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.9.1"
+  version: "0.10.0"
 
 package:
   name: "extramojo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/ExtraMojo/ExtraMojo.git
-    rev: ce2756b3751829a37059abf4a6a1fe12602efb82
+    rev: b27ca53cd0208ea57816094770389de7b0d46100
 
 build:
   number: 0

--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.9.0"
+  version: "0.9.1"
 
 package:
   name: "extramojo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/ExtraMojo/ExtraMojo.git
-    rev: 8941c78d2a1fef538d705dfd008e0108a78222a4
+    rev: ce2756b3751829a37059abf4a6a1fe12602efb82
 
 build:
   number: 0


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
