### PR TITLE
Release bridge v0.1.0

### DIFF
--- a/recipes/bridge/README.md
+++ b/recipes/bridge/README.md
@@ -12,17 +12,28 @@ from python import Python
 from bridge.numpy import ndarray_to_tensor
 
 var np = Python.import_module("numpy")
-np_array = np.array([[1, 2], [3, 4]], dtype=float)
+np_array = np.arange(6.0).reshape(2,3)
 mojo_tensor = ndarray_to_tensor[DType.float64](np_array)
+```
+Or to achieve the reverse:
+```mojo
+from tensor import Tensor
+
+from bridge.numpy import tensor_to_ndarray
+
+values = List[Float64](0.0, 1.0, 2.0, 3.0, 4.0, 5.0)
+mojo_tensor = Tensor[DType.float64](shape=(2, 3), list=values)
+np_array = tensor_to_ndarray(mojo_tensor)
 ```
 
 # Installation
-Add `https://repo.prefix.dev/modular-community` to the channels section of your of your
-`mojoproject.toml` file.
-Then run:
+Add the `modular-community` channel to  your `mojoproject.toml` file and `bridge` to
+your dependencies, by running:
 ```bash
+magic project channel add "https://repo.prefix.dev/modular-community"
 magic add bridge
 ```
+That's it, success! 🎉
 
 # Dependencies
 Requires numpy and mojo.

--- a/recipes/bridge/recipe.yaml
+++ b/recipes/bridge/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.1"
+  version: "0.1.0"
 
 package:
   name: "bridge"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://gitlab.com/hylkedonker/bridge.git
-    rev: bcbd2e6fd51c6187351d2e2f69c136c3c50253a6
+    rev: dc89432cb79b6eeef42e1755593ea3837c48d7dd
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
     - mojo package src/bridge -o ${{ PREFIX }}/lib/mojo/bridge.mojopkg
 requirements:
   host:
-    - max=24.6
+    - max=25.1
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
This pull request updates Bridge to v0.1.0, the first Mojo v25.1 compatible release.

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
