### PR TITLE
Update readme and recipe for numojo V0.6

### DIFF
--- a/recipes/numojo/README.md
+++ b/recipes/numojo/README.md
@@ -6,6 +6,8 @@ NuMojo is a library for numerical computing in Mojo 🔥 similar to NumPy, SciPy
 
 **[Explore the docs»](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo-Examples-and-Benchmarks/blob/main/docs/README.md)**  |  **[Changelog»](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/docs/changelog.md)**  |  **[Check out our Discord»](https://discord.gg/NcnSH5n26F)**
 
+**[中文·简»](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/docs/readme_zhs.md)**  |  **[中文·繁»](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/docs/readme_zht.md)**  |  **[日本語»](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/docs/readme_jp.md)**
+
 **Table of Contents**
 
 1. [About The Project](https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/README.MD#about-the-project)
@@ -40,26 +42,26 @@ Our primary objective is to develop a fast, comprehensive numerics library in Mo
 
 Core data types:
 
-- Native n-dimensional array (`numojo.core.ndarray.NDArray`).
-- Native 2-dimensional array, i.e., matrix (`numojo.core.matrix.Matrix`).
-- Native n-dimensional complex array (`numojo.core.complex_ndarray.ComplexNDArray`)
+- Native n-dimensional array (`numojo.NDArray`).
+- Native 2-dimensional array, i.e., matrix (`numojo.Matrix`).
+- Native n-dimensional complex array (`numojo.ComplexNDArray`)
 - Native fixed-dimension array (to be implemented when trait parameterization is available).
 
 Routines and objects:
 
-- Array creation routines (`numojo.routines.creation`)
-- Array manipulation routines (`numojo.routines.manipulation`)
-- Input and output (`numojo.routines.io`)
-- Linear algebra (`numojo.routines.linalg`)
-- Logic functions (`numojo.routines.logic`)
-- Mathematical functions (`numojo.routines.math`)
-- Exponents and logarithms (`numojo.routines.exponents`)
-- Extrema finding (`numojo.routines.extrema`)
-- Rounding (`numojo.routines.rounding`)
-- Trigonometric functions (`numojo.routines.trig`)
-- Random sampling (`numojo.routines.random`)
-- Sorting, searching, and counting (`numojo.routines.sorting`, `numojo.routines.searching`)
-- Statistics (`numojo.routines.statistics`)
+- Array creation routines (`numojo.creation`)
+- Array manipulation routines (`numojo.manipulation`)
+- Input and output (`numojo.io`)
+- Linear algebra (`numojo.linalg`)
+- Logic functions (`numojo.logic`)
+- Mathematical functions (`numojo.math`)
+- Exponents and logarithms (`numojo.exponents`)
+- Extrema finding (`numojo.extrema`)
+- Rounding (`numojo.rounding`)
+- Trigonometric functions (`numojo.trig`)
+- Random sampling (`numojo.random`)
+- Sorting and searching (`numojo.sorting`, `numojo.searching`)
+- Statistics (`numojo.statistics`)
 - etc...
 
 Please find all the available functions and objects [here](docs/features.md).
@@ -199,7 +201,7 @@ You can add `numojo` in the dependencies section of your toml file.
 
 ```toml
 [dependencies]
-numojo = "==0.5"
+numojo = "==0.6"
 ```
 
 ### Build package

--- a/recipes/numojo/recipe.yaml
+++ b/recipes/numojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.5.0"
+  version: "0.6.0"
 
 package:
   name: "numojo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo.git
-    rev: 4229b768d87b63896f527a7d52527ac1aec22fa2
+    rev: 23f316c9888249b40a7f2cbe5adc94e8ac632335
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
     - mojo package numojo -o ${{ PREFIX }}/lib/mojo/numojo.mojopkg
 requirements:
   host:
-    - max=24.6
+    - max=25.1.1
   run:
     - ${{ pin_compatible('max') }}
 
@@ -26,7 +26,7 @@ tests:
           - mojo run tests.mojo
     requirements:
       run:
-        - max=24.6
+        - max=25.1.1
         - numpy
     files:
       recipe:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
