### PR TITLE
Bump mojo-websockets version, compatible with max 25.2

### DIFF
--- a/recipes/mojo-websockets/recipe.yaml
+++ b/recipes/mojo-websockets/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.2"
+  version: "0.2.0"
 
 package:
   name: "websockets"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/msaelices/mojo-websockets.git
-    rev: 86ff5744e437fe2203ed8a1be5db62964f084e02
+    rev: 751c48ed576fe5a6113afd8ae83f6e48dedf832b
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - max == 25.1
+    - max == 25.2
   run:
     - ${{ pin_compatible('max') }}
 
@@ -27,7 +27,7 @@ tests:
           - mojo test tests/test_bytes.mojo
     requirements:
       run:
-        - max=25.1
+        - max=25.2
     files:
       recipe:
         - tests/test_bytes.mojo


### PR DESCRIPTION
**Checklist**
- [X] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [X] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [X] Set the build number to `0` (for new packages, or if the version changed).
- [X] Bumped the build number (if the version is unchanged).
