### PR TITLE
Mosaic: Update MAX to 25.2.0

### DIFF
--- a/recipes/mosaic/recipe.yaml
+++ b/recipes/mosaic/recipe.yaml
@@ -16,10 +16,10 @@ package:
 
 source:
   - git: https://github.com/christianbator/mosaic
-    rev: main
+    rev: 6890114b5189343f0181b3f70574fccb69f04a28
 
 build:
-  number: 0
+  number: 1
   script: build/build.sh
   dynamic_linking:
     missing_dso_allowlist:
@@ -31,7 +31,7 @@ requirements:
   build:
     - clang
   host:
-    - max==25.1.0
+    - max==25.2.0
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
### Description
Updated MAX to 25.2.0 for the new release 🎉

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
