### PR TITLE
New Mojmelo for Max 25.2

### DIFF
--- a/recipes/mojmelo/recipe.yaml
+++ b/recipes/mojmelo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.4"
+  version: "0.0.5"
 
 package:
   name: "mojmelo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/yetalit/mojmelo.git
-    rev: 83d9602424e3fe6cf01d4db06655e5f1bb2acbcf
+    rev: 6b998d367b583e3eb9da6bda4ade710a718e1db2
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
     - mojo package magic/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojopkg
 requirements:
   host:
-    - max =25.1
+    - max =25.2
   run:
     - ${{ pin_compatible('max') }}
 
@@ -27,7 +27,7 @@ tests:
           - mojo tests/setup.mojo
     requirements:
       run:
-        - max =25.1
+        - max =25.2
     files:
       recipe:
         - tests/setup.mojo

--- a/recipes/mojmelo/tests/mojmelo/utils/mojmelo_matmul/matmul.mojo
+++ b/recipes/mojmelo/tests/mojmelo/utils/mojmelo_matmul/matmul.mojo
@@ -7,7 +7,6 @@ from sys import has_avx512f, num_performance_cores, simdwidthof, sizeof
 import benchmark
 from testing import assert_equal
 from utils import IndexList
-from collections import InlineArray
 import random
 from .params import *
 

--- a/recipes/mojmelo/tests/setup.mojo
+++ b/recipes/mojmelo/tests/setup.mojo
@@ -1,7 +1,6 @@
 from sys import external_call, os_is_linux, os_is_macos, argv
 from sys.ffi import *
 from memory import UnsafePointer
-from collections import InlineArray
 
 fn cachel1() -> Int32:
     var l1_cache_size: c_int = 0
@@ -136,7 +135,6 @@ fn main() raises:
             return
 
         from mojmelo.utils.Matrix import Matrix
-        from collections import InlineArray
         import time
 
         alias NUM_ITER = 16


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
