### PR TITLE
bump emberjson to 0.1.4 for max 25.2 release

### DIFF
--- a/recipes/emberjson/recipe.yaml
+++ b/recipes/emberjson/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.1.3
+  version: 0.1.4
 
 package:
   name: "emberjson"
@@ -7,7 +7,7 @@ package:
 
 source:
  - git: https://github.com/bgreni/EmberJson.git
-   rev: 95cf7550379d7675084e2d6984eb1b81c3ac7ccc
+   rev: f2b2c89ad39fdd96f0b58036ed5e04478a3f2556
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - max =25.1
+    - max =25.2
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
