### PR TITLE
[mosaic] Version bump, specify clang version, and switch to lld linker

### DIFF
--- a/recipes/mosaic/recipe.yaml
+++ b/recipes/mosaic/recipe.yaml
@@ -16,20 +16,22 @@ package:
 
 source:
   - git: https://github.com/christianbator/mosaic.git
-    rev: 6890114b5189343f0181b3f70574fccb69f04a28
+    rev: 7d95b2e6c8e7348e7e18cffa9189dd2c40a41a80
 
 build:
-  number: 1
+  number: 2
   script: build/build.sh
   dynamic_linking:
     missing_dso_allowlist:
       - if: osx
         then:
           - /usr/lib/swift/libswift*.dylib
+          - /usr/lib/libc++*.dylib
 
 requirements:
   build:
-    - clang
+    - clang==20.1.4
+    - lld==20.1.4
   host:
     - max==25.2.0
   run:
@@ -41,7 +43,8 @@ tests:
       mojo test
     files:
       source:
-        - test/
+        - test/**.mojo
+        - test/data/
 
 about:
   homepage: https://mosaiclib.org


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
