### PR TITLE
Mist 25.3

### DIFF
--- a/recipes/mist/recipe.yaml
+++ b/recipes/mist/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.2"
+  version: "25.3.0"
 
 package:
   name: "mist"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/thatstoasty/mist.git
-    rev: bfe093f4d6fb74295b607d72b0a0ccb25447284d
+    rev: 44b33ed6fad24c11a593cecb7a9515b034d73a11
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
     - mojo package src/mist -o ${{ PREFIX }}/lib/mojo/mist.mojopkg
 requirements:
   host:
-    - max =25.2
+    - max =25.3
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
