### PR TITLE
Update mosaic to modular 25.3.0

### DIFF
--- a/recipes/mosaic/recipe.yaml
+++ b/recipes/mosaic/recipe.yaml
@@ -16,10 +16,10 @@ package:
 
 source:
   - git: https://github.com/christianbator/mosaic.git
-    rev: 7d95b2e6c8e7348e7e18cffa9189dd2c40a41a80
+    rev: 9be5ccdc0c00b5bc90e5d72db6774a068c925ae4
 
 build:
-  number: 2
+  number: 3
   script: build/build.sh
   dynamic_linking:
     missing_dso_allowlist:
@@ -33,7 +33,7 @@ requirements:
     - clang==20.1.4
     - lld==20.1.4
   host:
-    - max==25.2.0
+    - max==25.3.0
   run:
     - ${{ pin_compatible('max') }}
 
@@ -50,7 +50,7 @@ about:
   homepage: https://mosaiclib.org
   license: Apache-2.0
   license_file: LICENSE
-  summary: Open source computer vision library in Mojo
+  summary: An open source computer vision library in Mojo
   repository: https://github.com/christianbator/mosaic
   documentation: https://mosaiclib.org/docs
 


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
