### PR TITLE
Migration to pixi for Mojmelo

### DIFF
--- a/recipes/mojmelo/recipe.yaml
+++ b/recipes/mojmelo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.6"
+  version: "0.0.65"
 
 package:
   name: "mojmelo"
@@ -7,13 +7,13 @@ package:
 
 source:
   - git: https://github.com/yetalit/mojmelo.git
-    rev: f806ac2c072dd580dfe6c63d77e72c3c3de76c06
+    rev: 82991dfa4b71b7ed63b468e01be8d5798f4ba61b
 
 build:
   number: 0
   script:
-    - mojo package magic/mojmelo/utils/mojmelo_matmul -o ${{ PREFIX }}/lib/mojo/mojmelo_matmul.mojopkg
-    - mojo package magic/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojopkg
+    - mojo package pixi/mojmelo/utils/mojmelo_matmul -o ${{ PREFIX }}/lib/mojo/mojmelo_matmul.mojopkg
+    - mojo package pixi/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojopkg
 requirements:
   host:
     - max =25.3

--- a/recipes/mojmelo/tests/setup.sh
+++ b/recipes/mojmelo/tests/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-path="./.magic/envs/default/etc/conda/test-files/mojmelo/0/tests"
+path="./.pixi/envs/default/etc/conda/test-files/mojmelo/0/tests"
 curr=$(pwd)
 cd $path
 
@@ -17,4 +17,4 @@ mojo ./setup.mojo 9
 
 cd $curr
 
-mojo package $path/mojmelo/utils/mojmelo_matmul -o ./.magic/envs/default/lib/mojo/mojmelo_matmul.mojopkg
+mojo package $path/mojmelo/utils/mojmelo_matmul -o ./.pixi/envs/default/lib/mojo/mojmelo_matmul.mojopkg


### PR DESCRIPTION
**Checklist**
- [ ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
