### PR TITLE
Update numojo to v0.7.0

### DIFF
--- a/recipes/numojo/README.md
+++ b/recipes/numojo/README.md
@@ -187,21 +187,21 @@ fn main() raises:
 
 There are three approach to install and use the Numojo package.
 
-### Use magic CLI
+### Use pixi CLI
 
 You can use the following command in the terminal to install `numojo`.
 
 ```console
-magic add numojo 
+pixi add numojo 
 ```
 
 ### Add in toml file
 
-You can add `numojo` in the dependencies section of your toml file.
+You can add `pixi` in the dependencies section of your toml file.
 
 ```toml
 [dependencies]
-numojo = "==0.6"
+pixi = "==0.7.0"
 ```
 
 ### Build package
@@ -209,7 +209,7 @@ numojo = "==0.6"
 This approach involves building a standalone package file `mojopkg`.
 
 1. Clone the repository.
-2. Build the package using `magic run package`.
+2. Build the package using `pixi run package`.
 3. Move the `numojo.mojopkg` into the directory containing the your code.
 
 ### Include NuMojo's path for compiler and LSP

--- a/recipes/numojo/recipe.yaml
+++ b/recipes/numojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.6.1"
+  version: "0.7.0"
 
 package:
   name: "numojo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo.git
-    rev: f0dea371bfd15df65e917e013e11d6177bfc975a
+    rev: 2b72ef420f68329a5d99120e0cdb642f027ae837
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
     - mojo package numojo -o ${{ PREFIX }}/lib/mojo/numojo.mojopkg
 requirements:
   host:
-    - max=25.1.1
+    - max=25.3
   run:
     - ${{ pin_compatible('max') }}
 
@@ -26,7 +26,7 @@ tests:
           - mojo run tests.mojo
     requirements:
       run:
-        - max=25.1.1
+        - max=25.3
         - numpy
     files:
       recipe:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6. **Compatible with 25.3**.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged). **Not applicable**
