### PR TITLE
update kelvin to use 25.4

### DIFF
--- a/recipes/kelvin/recipe.yaml
+++ b/recipes/kelvin/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.1.0
+  version: 0.1.1
 
 package:
   name: "kelvin"
@@ -7,7 +7,7 @@ package:
 
 source:
  - git: https://github.com/bgreni/Kelvin.git
-   rev: 63e9affda4e4b09b1f147f240ad660980ba6daa1
+   rev: e8afbd34e7922e33ab9b5ab75333d1c816cdfe05
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - max =25.3
+    - max =25.4
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
