### PR TITLE
Ish 1 2 1

### DIFF
--- a/recipes/ish/recipe.yaml
+++ b/recipes/ish/recipe.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 
 context:
-  version: "1.2.0"
+  version: "1.2.1"
   modular_version: "=25.4"
   extramojo_version: "=0.15"
 
@@ -12,7 +12,7 @@ package:
 
 source:
   - git: https://github.com/BioRadOpenSource/ish.git
-    rev: e30ad09a2d21495d168522093fb643be130ddae3
+    rev: 5be7699230d9ea3eaa3701a3ffbfa6e37b5aed82
   # path: .
   # use_gitignore: true
 


### PR DESCRIPTION
Fixes logging issue that wasn't caught in tests. 

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
