### PR TITLE
Update DeciMojo to v0.4.1

### DIFF
--- a/recipes/decimojo/recipe.yaml
+++ b/recipes/decimojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.4.0"
+  version: "0.4.1"
 
 package:
   name: "decimojo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/forFudan/decimojo.git
-    rev: 8ed3dabd731f8948c6b9b04ff9ca16b55734fe3b
+    rev: 51c983229749df1caf490ccb9ddea19e7f220441
 
 build:
   number: 0


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
