### PR TITLE
New Mojmelo for Max 25.4

### DIFF
--- a/recipes/mojmelo/recipe.yaml
+++ b/recipes/mojmelo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.65"
+  version: "0.0.7"
 
 package:
   name: "mojmelo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/yetalit/mojmelo.git
-    rev: 82991dfa4b71b7ed63b468e01be8d5798f4ba61b
+    rev: a64647295d718fda0494d26f0152dcbf8c3ed340
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
     - mojo package pixi/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojopkg
 requirements:
   host:
-    - max =25.3
+    - max =25.4
   run:
     - ${{ pin_compatible('max') }}
 
@@ -27,7 +27,7 @@ tests:
           - mojo tests/setup.mojo
     requirements:
       run:
-        - max =25.3
+        - max =25.4
     files:
       recipe:
         - tests/setup.mojo

--- a/recipes/mojmelo/tests/mojmelo/utils/Matrix.mojo
+++ b/recipes/mojmelo/tests/mojmelo/utils/Matrix.mojo
@@ -2,7 +2,7 @@ from .mojmelo_matmul import matmul
 from memory import memcpy, memset_zero, UnsafePointer
 import random
 
-struct Matrix:
+struct Matrix(Copyable, Movable, Sized):
     var height: Int
     var width: Int
     var size: Int

--- a/recipes/mojmelo/tests/mojmelo/utils/mojmelo_matmul/matmul.mojo
+++ b/recipes/mojmelo/tests/mojmelo/utils/mojmelo_matmul/matmul.mojo
@@ -35,7 +35,7 @@ fn intsqrt[n: Int]() -> Int:
 
 @value
 @register_passable("trivial")
-struct Layout:
+struct Layout(Writable):
     var shape: IndexList[2]
     var strides: IndexList[2]
 


### PR DESCRIPTION
**Checklist**
- [ ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
