### PR TITLE
Update small_time to remove unneeded print statement

### DIFF
--- a/recipes/small_time/recipe.yaml
+++ b/recipes/small_time/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "25.4.0"
+  version: "25.4.1"
 
 package:
   name: "small_time"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/thatstoasty/small-time.git
-    rev: 04d8c7a3febbbb6707b11aeebb55b42d7f7d4129
+    rev: 5eb887d8efcf2d401d7ebef82f332550bcffbdb9
 
 build:
   number: 0


### PR DESCRIPTION
**Checklist**
- [ ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
