### PR TITLE
bump emberjson for 25.5

### DIFF
--- a/recipes/emberjson/recipe.yaml
+++ b/recipes/emberjson/recipe.yaml
@@ -1,5 +1,6 @@
 context:
-  version: 0.1.6
+  version: 0.1.7
+  mojo_version: "=25.5"
 
 package:
   name: "emberjson"
@@ -7,7 +8,7 @@ package:
 
 source:
  - git: https://github.com/bgreni/EmberJson.git
-   rev: c12f69c21311807ddb998ca1a75be0db0ac2f8dc
+   rev: 0700a32337a7f348d92434240e52a62b881e92b3
 
 build:
   number: 0
@@ -16,15 +17,22 @@ build:
 
 requirements:
   host:
-    - max =25.4
+    - mojo-compiler ${{ mojo_version }}
+  build:
+    - mojo-compiler ${{ mojo_version }}
   run:
-    - ${{ pin_compatible('max') }}
+    - ${{ pin_compatible('mojo-compiler') }}
 
 tests:
   - script:
     - if: unix
       then:
         - mojo test
+    requirements:
+      build:
+        - mojo ${{ mojo_version }}
+      run:
+        - mojo ${{ mojo_version }}
 
 about:
   homepage: https://github.com/bgreni/EmberJson


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
