### PR TITLE
update extramojo for 25.5

### DIFF
--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -28,15 +28,16 @@ tests:
   - script:
       - if: unix
         then:
-          - mojo run -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests/test_file.mojo
-          - mojo test -I ${{ PREFIX }}/lib/mojo/extramojo.mojopkg tests
+          - mojo run -I . tests/test_file.mojo
+          - mojo test -I . tests
     requirements:
       build:
-        - mojo-compiler ${{ mojo_version }}
+        - mojo ${{ mojo_version }}
       run:
-        - mojo-compiler ${{ mojo_version }}
+        - mojo ${{ mojo_version }}
     files:
       source:
+        - extramojo/
         - tests/
 
 about:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
