### PR TITLE
Mojo regex - 0.4.0 

### DIFF
--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -18,12 +18,12 @@ context:
   version: 13.4.2
 package:
   name: mojo-regex
-  version: 0.2.1
+  version: 0.4.0
 requirements:
   host:
-    - max =25.4.0
+    - max =25.5.0
   run:
     - ${{ pin_compatible('max') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: cc187a5987143b0eb7d9497e6ddb7546f2296e9c
+    rev: 7241fc7435b0516eaf24fe812ead25077a87491b


### PR DESCRIPTION
**Checklist**
- [X] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [X] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [X] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
