### PR TITLE
Bump mist for Mojo 25.5

### DIFF
--- a/recipes/mist/recipe.yaml
+++ b/recipes/mist/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "25.4.0"
+  version: "25.5.0"
 
 package:
   name: "mist"
@@ -7,15 +7,15 @@ package:
 
 source:
   - git: https://github.com/thatstoasty/mist.git
-    rev: 6edf8a17c6f2e0dd7bf194f6dc3d032c0b9d091b
+    rev: 1c89c766f2827607c2fe64cfdc13b8680d55d6c0
 
 build:
   number: 0
   script:
-    - mojo package src/mist -o ${{ PREFIX }}/lib/mojo/mist.mojopkg
+    - mojo package mist -o ${{ PREFIX }}/lib/mojo/mist.mojopkg
 requirements:
   host:
-    - max =25.4
+    - max =25.5
   run:
     - ${{ pin_compatible('max') }}
 


### PR DESCRIPTION
**Checklist**
- [ ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
