### PR TITLE
Bump Mojmelo for MAX 25.5

### DIFF
--- a/recipes/mojmelo/recipe.yaml
+++ b/recipes/mojmelo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.0.75"
+  version: "0.0.8"
 
 package:
   name: "mojmelo"
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/yetalit/mojmelo.git
-    rev: db1118cbb1eb845de10012d72113080d15f0d9c6
+    rev: 04f2b8b4c2a8e495b8e05ad7d7554e1b644df66d
 
 build:
   number: 0
@@ -16,7 +16,7 @@ build:
     - mojo package pixi/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojopkg
 requirements:
   host:
-    - max =25.4
+    - max =25.5
   run:
     - ${{ pin_compatible('max') }}
 
@@ -27,7 +27,7 @@ tests:
           - mojo tests/setup.mojo
     requirements:
       run:
-        - max =25.4
+        - max =25.5
     files:
       recipe:
         - tests/setup.mojo

--- a/recipes/mojmelo/tests/mojmelo/utils/Matrix.mojo
+++ b/recipes/mojmelo/tests/mojmelo/utils/Matrix.mojo
@@ -1,5 +1,5 @@
 from .mojmelo_matmul import matmul
-from memory import memcpy, memset_zero, UnsafePointer
+from memory import memcpy, memset_zero
 import random
 
 struct Matrix(Copyable, Movable, Sized):
@@ -37,15 +37,15 @@ struct Matrix(Copyable, Movable, Sized):
         self.order = other.order
         memcpy(self.data, other.data, self.size)
 
-    fn __moveinit__(out self, owned existing: Self):
+    fn __moveinit__(out self, var existing: Self):
         self.height = existing.height
         self.width = existing.width
         self.size = existing.size
         self.data = existing.data
         self.order = existing.order
-        existing.height = existing.width = existing.size = 0
-        existing.order = ''
-        existing.data = UnsafePointer[Float32]()
+        #existing.height = existing.width = existing.size = 0
+        #existing.order = ''
+        #existing.data = UnsafePointer[Float32]()
 
     # access an element
     @always_inline
@@ -60,7 +60,7 @@ struct Matrix(Copyable, Movable, Sized):
         return self.data[loc]
 
     @always_inline
-    fn __del__(owned self):
+    fn __del__(var self):
         if self.data:
             self.data.free()
 

--- a/recipes/mojmelo/tests/setup.mojo
+++ b/recipes/mojmelo/tests/setup.mojo
@@ -1,6 +1,5 @@
-from sys import external_call, os_is_linux, os_is_macos, argv
+from sys import external_call, CompilationTarget, argv
 from sys.ffi import *
-from memory import UnsafePointer
 
 fn cachel1() -> Int32:
     var l1_cache_size: c_int = 0
@@ -93,7 +92,7 @@ fn main() raises:
         cache_l2_size = 0
         cache_l1_associativity = 0
         cache_l2_associativity = 0
-        if os_is_linux():
+        if CompilationTarget.is_linux():
             with open("/sys/devices/system/cpu/cpu0/cache/index0/size", "r") as f:
                 txt = f.read()
                 if txt.find('K') != -1:
@@ -116,7 +115,7 @@ fn main() raises:
                     cache_l2_associativity = atol(f.read())
             except:
                 cache_l2_associativity = 0
-        elif os_is_macos():
+        elif CompilationTarget.is_macos():
             cache_l1_size = Int(cachel1())
             cache_l2_size = Int(cachel2())
         initialize(cache_l1_size, cache_l1_associativity, cache_l2_size, cache_l2_associativity)


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
