### PR TITLE
chore: update extramojo to 0.18.0

### DIFF
--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "0.17.0"
-  mojo_version: "=25.5"
+  version: "0.18.0"
+  mojo_version: "=0.25.6"
 
 package:
   name: "extramojo"
@@ -8,7 +8,7 @@ package:
 
 source:
   - git: https://github.com/ExtraMojo/ExtraMojo.git
-    rev: 608ca09f3b2e201b8c163f466966af48fa99e1c2
+    rev: 01b09557f73fb3a1a64bf48d3ef39fa826b24703
   # path: .
   # use_gitignore: true
 


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
