### PR TITLE
Fix build for pontoneer and address feedback

### DIFF
--- a/recipes/pontoneer/recipe.yaml
+++ b/recipes/pontoneer/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 # Bump this to match the git tag before tagging a release (e.g. v0.1.1 → "0.1.1").
 context:
   version: "0.6.0"
-  mojo_version: ">=0.26.0.dev2026030505"
+  mojo_version: "0.26.3.0.dev2026031505"
 
 package:
   name: pontoneer
@@ -16,7 +16,7 @@ source:
   tag: v${{ version }}
 
 build:
-  number: 0
+  number: 1
   # mojopkg files are architecture-independent source; skip the binary prefix
   # rewrite pass by marking this as a noarch package.
   noarch: generic
@@ -25,8 +25,12 @@ build:
     - mojo package pontoneer -o "${PREFIX}/lib/mojo/pontoneer.mojopkg"
 
 requirements:
+  host:
+    - mojo-compiler = ${{ mojo_version }}
   build:
-    - mojo
+    - mojo-compiler = ${{ mojo_version }}
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
 
 about:
   homepage: https://winding-lines.github.io/pontoneer/


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
