### PR TITLE
Bump mojo-regex to 0.10.0

### DIFF
--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 01b21e27d9cbc4f79d39c1bb1b40bdb3f9cc04dd
+    rev: ff0212c2109dae036d9a83c1eb67180308c0c4c6

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: ff0212c2109dae036d9a83c1eb67180308c0c4c6
+    rev: c8a5b56628ac87a14375676e6c6edc4594f82713

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.9.0
+  version: 0.10.0
   mojo_version: "=0.26.2"
 about:
   description: "# Mojo Regex\nRegular Expressions Library for Mojo\n\n`mojo-regex` is a\
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 762c4569fefe09a0a01f6900d5a351a6a4e76de5
+    rev: 8e56a946c8d315da624b65f6a46b0eea7eb67aae

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 1428daad981cfc3b80bea4fa4b3bff1fb11c633e
+    rev: 127c69fe93981221d88a4ec8264265c901ad3221

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 12ca959afcd2e8145d027282c70ff4d3d4c88e9d
+    rev: a686999b3d6e7f8db47f96ac0a20d6d71a1a41d9

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 26d3f5cea5b0d470daa801c92faea384ff096234
+    rev: 16ee6e1c7e8e7b994e19405fa2b2dbcce209bfef

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 8e56a946c8d315da624b65f6a46b0eea7eb67aae
+    rev: cbfdabc07804eccce24b19277b482072c6b969a1

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 3b0079cc5a9a76a119cb356320f496000aa39d94
+    rev: 01b21e27d9cbc4f79d39c1bb1b40bdb3f9cc04dd

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: f0b3172650ed831905008e76ac74dd6f5434af76
+    rev: 3b0079cc5a9a76a119cb356320f496000aa39d94

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: c65d5c899ec753040b6e583a2cc78e60a770bd42
+    rev: dfd54cd697cf47a3ef62cac3630276bbfef42d8a

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 16ee6e1c7e8e7b994e19405fa2b2dbcce209bfef
+    rev: c65d5c899ec753040b6e583a2cc78e60a770bd42

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: e8672ffad432c9769cf1703d30c985fc226670af
+    rev: 6826129f0e8e133c40c7f31d64eb709011e67887

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: cbfdabc07804eccce24b19277b482072c6b969a1
+    rev: 6a8a0bd0e793527c5fc5acab881825b95a5da36b

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 6826129f0e8e133c40c7f31d64eb709011e67887
+    rev: 1428daad981cfc3b80bea4fa4b3bff1fb11c633e

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: dfd54cd697cf47a3ef62cac3630276bbfef42d8a
+    rev: e8672ffad432c9769cf1703d30c985fc226670af

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 6a8a0bd0e793527c5fc5acab881825b95a5da36b
+    rev: 26d3f5cea5b0d470daa801c92faea384ff096234

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: c8a5b56628ac87a14375676e6c6edc4594f82713
+    rev: 12ca959afcd2e8145d027282c70ff4d3d4c88e9d

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 127c69fe93981221d88a4ec8264265c901ad3221
+    rev: f0b3172650ed831905008e76ac74dd6f5434af76


### PR DESCRIPTION
Bumps mojo-regex from 0.9.0 to 0.10.0. Performance tuning release . Mojo vs Rust win rate improved from 57% to 64%.

Changes since 0.9.0 (all in [msaelices/mojo-regex](https://github.com/msaelices/mojo-regex)):

- [#93](https://github.com/msaelices/mojo-regex/pull/93): SIMD range comparison for contiguous byte ranges. `range_lowercase` 9.4x faster than Python.
- [#94](https://github.com/msaelices/mojo-regex/pull/94): DFA inner-loop optimization. 1.3-1.8x faster on DFA-heavy findall.
- [#95](https://github.com/msaelices/mojo-regex/pull/95): `StringSlice` text parameter through the matcher chain. ~11% average speedup.
- [#98](https://github.com/msaelices/mojo-regex/pull/98): `NFAMatcher` lazy DFA initialization fix (`init_pointee_move`).
- [#99](https://github.com/msaelices/mojo-regex/pull/99): `StringSlice` pattern parameter + hash-keyed regex cache.
- [#102](https://github.com/msaelices/mojo-regex/pull/102): Inline NFA per-character range checks (Dict lookup removal).
- [#103](https://github.com/msaelices/mojo-regex/pull/103): Implement `re.sub()` for regex pattern substitution.
- [#104](https://github.com/msaelices/mojo-regex/pull/104): Precompute range classification tag on ASTNode. Net -14% code in nfa.mojo.
- [#105](https://github.com/msaelices/mojo-regex/pull/105): Eliminate per-match String copies in DFA/NFA hot paths.
- [#106](https://github.com/msaelices/mojo-regex/pull/106): Add `sub()` comparison benchmarks. vs Python: 5/5 wins (1.2x-9.0x faster).
- [#108](https://github.com/msaelices/mojo-regex/pull/108): Capture group extraction and `\1`..\`\9` interpolation in `sub()`.
- [#110](https://github.com/msaelices/mojo-regex/pull/110): DFA fast path for `sub()` on fixed-width `\d{N}` capture groups. Skips NFA entirely, computes group boundaries via pointer arithmetic. Beats Python 2.8-3.2x and Rust 1.5-1.9x on phone number formatting.

Recipe changes:
- `version`: 0.9.0 -> 0.10.0
- `rev`: pinned to `127c69fe93981221d88a4ec8264265c901ad3221` (current `main` HEAD).