### PR TITLE
Bump mojo-regex from 0.10.0 to 0.11.0

### DIFF
--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 3560e81
+    rev: 2a321c6

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 1934d75771c195b6e90c2f345809eeb8cd7a3966
+    rev: 11de609b4824dc76ab4aa8c049051eed895ddfe0

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 9da054ba6caef29939c81f092d9efbeb3acf53c8
+    rev: 3560e81

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: dc3e955
+    rev: fb53ebb

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 85956f8
+    rev: a550388

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: af96191
+    rev: 533b069

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: fb53ebb
+    rev: 3357e6d

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 3357e6d
+    rev: 85956f8

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 533b069
+    rev: dc3e955

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 101a3cb3f264a8da7a3cbe7e257bc7a1a008c28b
+    rev: 1934d75771c195b6e90c2f345809eeb8cd7a3966

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 11de609b4824dc76ab4aa8c049051eed895ddfe0
+    rev: 9da054ba6caef29939c81f092d9efbeb3acf53c8

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: 2a321c6
+    rev: af96191

--- a/recipes/mojo-regex/recipe.yaml
+++ b/recipes/mojo-regex/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.10.0
+  version: 0.11.0
   mojo_version: "=0.26.2"
 about:
   description: "# Mojo Regex\nRegular Expressions Library for Mojo\n\n`mojo-regex` is a\
@@ -7,7 +7,7 @@ about:
     \ that automatically optimizes pattern matching based on complexity.\n\nIt aims\
     \ to provide a similar interface as the [re](https://docs.python.org/3/library/re.html)\
     \ stdlib package while leveraging Mojo's performance capabilities.\n\nBeats Python's\
-    \ C-based `re` module on 100% of benchmarks."
+    \ C-based `re` module on 97% of benchmarks. Beats Rust's `regex` crate on 60%."
   homepage: https://github.com/msaelices/mojo-regex
   license: MIT
   license_file: LICENSE
@@ -30,4 +30,4 @@ requirements:
     - ${{ pin_compatible('mojo-compiler') }}
 source:
   - git: https://github.com/msaelices/mojo-regex.git
-    rev: a686999b3d6e7f8db47f96ac0a20d6d71a1a41d9
+    rev: 101a3cb3f264a8da7a3cbe7e257bc7a1a008c28b


### PR DESCRIPTION
Bumps mojo-regex from 0.10.0 to 0.11.0.

## Changes since 0.10.0

- [#145](https://github.com/msaelices/mojo-regex/pull/145): Perf deep-dive: range-path find_first + precomputed OnePass end-anchor. `phone_validation` **315 → 28 ns (11.2x, now faster than Rust)**, `predefined_digits` 2.08x, `sparse_phone_search` 1.87x, `range_digits` 1.74x, `multi_format_phone` 1.58x.
- [#144](https://github.com/msaelices/mojo-regex/pull/144): Pattern + repl identity cache for module-level `sub()`. ES `(\d{3})(\d{2})(\d{2})(\d{2})` 559 → 192 ns (2.9x), US `(\d{3})(\d{3})(\d{4})` 535 → 166 ns (3.2x).
- [#143](https://github.com/msaelices/mojo-regex/pull/143): Precompute fixed-width `sub()` metadata; short-circuit whole-text matches. Fixes a latent correctness bug where the old fast path produced garbage on non-matching text of the right length.
- b0179a0: Hoist redundant `ast.get_value()` call in NFA `_match_range` character paths. Avoids two `Optional[StringSlice]` constructions per input character for `RANGE_KIND_COMPLEX_ALNUM` / `RANGE_KIND_OTHER` bracket patterns on the backtracking-NFA inner loop.
- [#140](https://github.com/msaelices/mojo-regex/pull/140): OnePass NFA engine for `$`-anchored patterns. `phone_validation` (5x median): 1.76 us → 0.25 us (**6.92x faster**). Full bench geom 1.09x across 80 benchmarks.
- [#139](https://github.com/msaelices/mojo-regex/pull/139): Single-byte required-literal memchr prefilter for findall. `sparse_email_findall` **~160x faster** (199 us → 1.25 us, was 167x slower than Rust, now within 5%); `simple_phone` 4.4x; full bench geom 1.32x.
- [#138](https://github.com/msaelices/mojo-regex/pull/138): Two-way unroll of `count_consecutive_matches` SIMD loops (range_lowercase **7.77x faster**, range_alphanumeric **3.1x faster**, range_digits 1.4x; via `@always_inline` helpers)
- [#137](https://github.com/msaelices/mojo-regex/pull/137): `--dev` and `--filter` flags for bench_engine, plus CLAUDE.md / BENCHMARKING_GUIDE.md docs (fast dev iteration: full bench ~4 min -> ~8 s)
- [#136](https://github.com/msaelices/mojo-regex/pull/136): Inline `match_next` dispatchers + pre-allocate `MatchList` in findall (sub() 8/0 wins 1.28x geom; top: deep_nested_groups 2.95x, complex_group_5_children 1.70x, simple_phone 1.60x)
- [#135](https://github.com/msaelices/mojo-regex/pull/135): Precompute pattern properties, eliminate string ops from match paths (nanpa_search 17.9x faster)
- [#133](https://github.com/msaelices/mojo-regex/pull/133): Use ref instead of copy for ASTNode in NFA match methods (findall 2.6-2.9x faster, free functions 1.6x faster)
- [#132](https://github.com/msaelices/mojo-regex/pull/132): Fix lazy DFA $ anchor bug, apply cache pointer to all free functions
- [#127](https://github.com/msaelices/mojo-regex/pull/127): Eliminate CompiledRegex copy in sub() via cache pointer lookup (33x faster per call)
- [#126](https://github.com/msaelices/mojo-regex/pull/126): Multi-range SIMD scan for [a-zA-Z0-9]+ patterns (9x faster)
- [#124](https://github.com/msaelices/mojo-regex/pull/124): Increase PikeVM MAX_STATES to 512, enabling lazy DFA for NANPA patterns
- [#122](https://github.com/msaelices/mojo-regex/pull/122): Cache DFA dispatch + inline LazyDFA helpers
- [#121](https://github.com/msaelices/mojo-regex/pull/121): Fix UInt8 overflow for patterns with >255 AST nodes
- [#119](https://github.com/msaelices/mojo-regex/pull/119): Skip dead _create_range_matcher indirection
- [#118](https://github.com/msaelices/mojo-regex/pull/118): Fix 3+ way alternation with character classes failing to match

## Benchmark summary

- `phone_validation` was 55x slower than Rust before #140 and 9x slower after #140; **now 1.12x FASTER than Rust** after #145
- `sparse_email_findall` was 167x slower than Rust before #139, now within 5%
- `range_lowercase` was 33x slower than Rust before #138, now ~3x
- vs Python: 97% win rate, geo mean **~24x**
- vs Rust: 80% win rate, geo mean **~3.2x**

Recipe changes:
- version: 0.10.0 -> 0.11.0
- rev: pinned to a550388
