### PR TITLE
bump emberjson to 0.3.2

### DIFF
--- a/recipes/emberjson/recipe.yaml
+++ b/recipes/emberjson/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.3.1
+  version: 0.3.2
 
 package:
   name: "emberjson"
@@ -7,7 +7,7 @@ package:
 
 source:
  - git: https://github.com/bgreni/EmberJson.git
-   rev: a3db99121379b553cd887f23f9a844cdace95ee8
+   rev: f8aa1d74630afefa3b552d9443d7ac1e3455c4be
 
 build:
   number: 0
@@ -16,9 +16,9 @@ build:
 
 requirements:
   host:
-    - mojo-compiler =0.26.2
+    - mojo-compiler =1.0.0b1
   build:
-    - mojo-compiler =0.26.2
+    - mojo-compiler =1.0.0b1
   run:
     - ${{ pin_compatible('mojo-compiler') }}
 
@@ -35,9 +35,9 @@ tests:
         - bench_data/
     requirements:
       build:
-        - mojo =0.26.2
+        - mojo =1.0.0b1
       run:
-        - mojo =0.26.2
+        - mojo =1.0.0b1
 
 about:
   homepage: https://github.com/bgreni/EmberJson


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
