### PR TITLE
chore: update extramojo for v1.0.0b1

### DIFF
--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "0.21.1"
-  mojo_version: "=0.26.2"
+  version: "0.22.0"
+  mojo_version: "=1.0.0b1"
 
 package:
   name: "extramojo"
@@ -8,7 +8,7 @@ package:
 
 source:
   - git: https://github.com/ExtraMojo/ExtraMojo.git
-    rev: 6515711dbeb109779fc99007273793d55449e325
+    rev: ce25d17d117b2956e669c808aa326f5a6fb4bbdc
   # path: .
   # use_gitignore: true
 

--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -37,19 +37,28 @@ tests:
             if command -v lscpu >/dev/null 2>&1; then
               lscpu
             fi
-            first_test="$(find ./tests -name 'test_*.mojo' | sort | head -n 1)"
-            mojo build --print-effective-target -I . -D ASSERT=all "${first_test}" || exit $?
+            target_features=""
+            if [ "$(uname -m)" = "x86_64" ]; then
+              target_features="--target-features -avx512bf16,-avx512bitalg,-avx512bw,-avx512cd,-avx512dq,-avx512f,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vl,-avx512vnni,-avx512vpopcntdq"
+            fi
+            bbhash_test="./tests/collections/bbhash/test_bbhash.mojo"
+            echo "Default target configuration"
+            mojo build --print-effective-target -I . -D ASSERT=all "${bbhash_test}" || exit $?
+            if [ -n "${target_features}" ]; then
+              echo "A/B test: ${bbhash_test} with default target"
+              if mojo run -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}"; then
+                echo "A/B default target passed"
+              else
+                status=$?
+                echo "A/B default target failed with status ${status}"
+              fi
+              echo "A/B test: ${bbhash_test} with AVX-512 disabled"
+              mojo build ${target_features} --print-effective-target -I . -D ASSERT=all "${bbhash_test}" || exit $?
+              mojo run ${target_features} -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}" || exit $?
+            fi
             for test in $(find ./tests -name 'test_*.mojo' | sort); do
               echo "Running ${test} with mojo run"
-              mojo run -debug-level=line-tables -I . -D ASSERT=all "${test}"
-              status=$?
-              if [ "${status}" -eq 0 ]; then
-                continue
-              fi
-              echo "mojo run failed for ${test} with status ${status}; rebuilding with debug info"
-              mojo build -debug-level=line-tables -I . -D ASSERT=all "${test}" -o /tmp/extramojo_test || exit "${status}"
-              /tmp/extramojo_test || true
-              exit "${status}"
+              mojo run ${target_features} -debug-level=line-tables -I . -D ASSERT=all "${test}" || exit $?
             done
     requirements:
       build:

--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -28,7 +28,29 @@ tests:
   - script:
       - if: unix
         then:
-          - sh -c 'find ./tests -name test_*.mojo | xargs -I % pixi run mojo run -I . -D ASSERT=all %'
+          - |
+            set -u
+            echo "ExtraMojo package test diagnostics"
+            uname -a
+            command -v mojo
+            mojo --version
+            if command -v lscpu >/dev/null 2>&1; then
+              lscpu
+            fi
+            first_test="$(find ./tests -name 'test_*.mojo' | sort | head -n 1)"
+            mojo build --print-effective-target -I . -D ASSERT=all "${first_test}" || exit $?
+            for test in $(find ./tests -name 'test_*.mojo' | sort); do
+              echo "Running ${test} with mojo run"
+              mojo run -debug-level=line-tables -I . -D ASSERT=all "${test}"
+              status=$?
+              if [ "${status}" -eq 0 ]; then
+                continue
+              fi
+              echo "mojo run failed for ${test} with status ${status}; rebuilding with debug info"
+              mojo build -debug-level=line-tables -I . -D ASSERT=all "${test}" -o /tmp/extramojo_test || exit "${status}"
+              /tmp/extramojo_test || true
+              exit "${status}"
+            done
     requirements:
       build:
         - mojo ${{ mojo_version }}

--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -47,14 +47,27 @@ tests:
             if [ -n "${target_features}" ]; then
               echo "A/B test: ${bbhash_test} with default target"
               if mojo run -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}"; then
+                default_status=0
                 echo "A/B default target passed"
               else
-                status=$?
-                echo "A/B default target failed with status ${status}"
+                default_status=$?
+                echo "A/B default target failed with status ${default_status}"
               fi
               echo "A/B test: ${bbhash_test} with AVX-512 disabled"
               mojo build ${target_features} --print-effective-target -I . -D ASSERT=all "${bbhash_test}" || exit $?
-              mojo run ${target_features} -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}" || exit $?
+              if mojo run ${target_features} -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}"; then
+                echo "A/B AVX-512-disabled target passed"
+                if [ "${default_status}" -eq 0 ]; then
+                  echo "DIAGNOSTIC RESULT: default target passed; runner did not reproduce the failure."
+                else
+                  echo "DIAGNOSTIC RESULT: default target failed, AVX-512-disabled target passed."
+                fi
+                echo "Intentionally failing this diagnostic run so rattler-build exposes the A/B transcript."
+                exit 86
+              fi
+              limited_status=$?
+              echo "DIAGNOSTIC RESULT: AVX-512-disabled target failed with status ${limited_status}."
+              exit "${limited_status}"
             fi
             for test in $(find ./tests -name 'test_*.mojo' | sort); do
               echo "Running ${test} with mojo run"

--- a/recipes/ExtraMojo/recipe.yaml
+++ b/recipes/ExtraMojo/recipe.yaml
@@ -30,44 +30,11 @@ tests:
         then:
           - |
             set -u
-            echo "ExtraMojo package test diagnostics"
-            uname -a
-            command -v mojo
-            mojo --version
-            if command -v lscpu >/dev/null 2>&1; then
-              lscpu
-            fi
             target_features=""
             if [ "$(uname -m)" = "x86_64" ]; then
+              # Mojo 1.0.0b1's default znver4 target enables AVX-512 on GitHub's
+              # linux-64 runner, whose exposed CPU flags do not include AVX-512.
               target_features="--target-features -avx512bf16,-avx512bitalg,-avx512bw,-avx512cd,-avx512dq,-avx512f,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vl,-avx512vnni,-avx512vpopcntdq"
-            fi
-            bbhash_test="./tests/collections/bbhash/test_bbhash.mojo"
-            echo "Default target configuration"
-            mojo build --print-effective-target -I . -D ASSERT=all "${bbhash_test}" || exit $?
-            if [ -n "${target_features}" ]; then
-              echo "A/B test: ${bbhash_test} with default target"
-              if mojo run -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}"; then
-                default_status=0
-                echo "A/B default target passed"
-              else
-                default_status=$?
-                echo "A/B default target failed with status ${default_status}"
-              fi
-              echo "A/B test: ${bbhash_test} with AVX-512 disabled"
-              mojo build ${target_features} --print-effective-target -I . -D ASSERT=all "${bbhash_test}" || exit $?
-              if mojo run ${target_features} -debug-level=line-tables -I . -D ASSERT=all "${bbhash_test}"; then
-                echo "A/B AVX-512-disabled target passed"
-                if [ "${default_status}" -eq 0 ]; then
-                  echo "DIAGNOSTIC RESULT: default target passed; runner did not reproduce the failure."
-                else
-                  echo "DIAGNOSTIC RESULT: default target failed, AVX-512-disabled target passed."
-                fi
-                echo "Intentionally failing this diagnostic run so rattler-build exposes the A/B transcript."
-                exit 86
-              fi
-              limited_status=$?
-              echo "DIAGNOSTIC RESULT: AVX-512-disabled target failed with status ${limited_status}."
-              exit "${limited_status}"
             fi
             for test in $(find ./tests -name 'test_*.mojo' | sort); do
               echo "Running ${test} with mojo run"


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
