### PR TITLE
Add mojo UUID package 

### DIFF
--- a/recipes/uuid/recipe.yaml
+++ b/recipes/uuid/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/lczerniawski/uuid.git
-    rev: b672f328840fac831a3d55e247ea744a853ef530
+    rev: 3e928b20ad4071de1bf84ec6666c09bd9dfc1514
 
 build:
   number: 0

--- a/recipes/uuid/recipe.yaml
+++ b/recipes/uuid/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  version: "1.0.0"
+
+package:
+  name: uuid
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/lczerniawski/uuid.git
+    rev: b672f328840fac831a3d55e247ea744a853ef530
+
+build:
+  number: 0
+  script:
+    - mojo package src/uuid -o ${{ PREFIX }}/lib/mojo/uuid.mojopkg
+
+requirements:
+  build:
+    - mojo-compiler =1.0.0b1
+  host:
+    - mojo-compiler =1.0.0b1
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run test.mojo
+    files:
+      recipe:
+        - test.mojo
+
+about:
+  homepage: https://github.com/lczerniawski/uuid
+  repository: https://github.com/lczerniawski/uuid
+  license: MIT
+  license_file: LICENSE
+  summary: A high-performance Mojo library for generating, parsing, validating, and formatting UUID values in RFC-9562 compatible string forms.
+
+extra:
+  maintainers:
+    - lczerniawski 

--- a/recipes/uuid/recipe.yaml
+++ b/recipes/uuid/recipe.yaml
@@ -40,4 +40,4 @@ about:
 
 extra:
   maintainers:
-    - lczerniawski 
+    - lczerniawski

--- a/recipes/uuid/test.mojo
+++ b/recipes/uuid/test.mojo
@@ -1,0 +1,31 @@
+from uuid import Generator, UUID, Version, Variant
+
+
+def main() raises:
+    var generator = Generator()
+
+    var uuid_v4 = generator.v4()
+    var uuid_v4_str = uuid_v4.to_string()
+    UUID.validate(uuid_v4_str)
+
+    if uuid_v4.version() != Version(Version.v4):
+        raise Error("Expected v4 UUID version bits")
+
+    if uuid_v4.variant() != Variant(Variant.RFC9562):
+        raise Error("Expected RFC9562 variant for v4 UUID")
+
+    var uuid_v7 = generator.v7()
+    var uuid_v7_str = uuid_v7.to_string()
+    UUID.validate(uuid_v7_str)
+
+    if uuid_v7.version() != Version(Version.v7):
+        raise Error("Expected v7 UUID version bits")
+
+    if uuid_v7.variant() != Variant(Variant.RFC9562):
+        raise Error("Expected RFC9562 variant for v7 UUID")
+
+    var parsed = UUID.from_string(uuid_v7_str)
+    if parsed.to_string() != uuid_v7_str:
+        raise Error("Round-trip parse/format failed")
+
+    print("Conda package smoke test passed")


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
