### PR TITLE
feat: add projectodyssey recipe (pinned at c27b76b)

### DIFF
--- a/recipes/projectodyssey/recipe.yaml
+++ b/recipes/projectodyssey/recipe.yaml
@@ -1,0 +1,49 @@
+context:
+  version: "0.1.0"
+  mojo_version: ">=1.0.0b1"
+
+package:
+  name: "projectodyssey"
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/HomericIntelligence/ProjectOdyssey
+    rev: c27b76b5e5c95fe8264ada0096b6f1a0dcc77f50
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${PREFIX}/lib/mojo
+    - mojo package -I src src/projectodyssey -o ${PREFIX}/lib/mojo/projectodyssey.mojopkg
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run -I ${PREFIX}/lib/mojo conda.recipe/test_import.mojo
+    requirements:
+      run:
+        - mojo-compiler ${{ mojo_version }}
+    files:
+      source:
+        - conda.recipe/test_import.mojo
+
+about:
+  homepage: https://github.com/HomericIntelligence/ProjectOdyssey
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Mojo-based AI research platform for reproducing classic research papers. Provides reusable tensor ops, autograd, layers, optimizers, and training infrastructure.
+  repository: https://github.com/HomericIntelligence/ProjectOdyssey.git
+
+extra:
+  project_name: projectodyssey
+  maintainers:
+    - mvillmow

--- a/recipes/projectodyssey/test_import.mojo
+++ b/recipes/projectodyssey/test_import.mojo
@@ -1,0 +1,22 @@
+# Smoke test executed by the `tests:` block in recipe.yaml.
+#
+# Imports canonical public symbols from the installed projectodyssey.mojopkg
+# and instantiates one to prove the package is not just parseable but
+# actually usable. If any import or instantiation fails, rattler-build
+# fails the package test and the recipe is rejected.
+#
+# Positive imports only: Mojo import failures are compile-time errors,
+# so there is no equivalent of pytest.raises(ImportError) here.
+
+from projectodyssey.tensor.tensor import Tensor
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+
+
+def main() raises:
+    # Compile-time-typed tensor.
+    var _t = Tensor[DType.float32]([2, 3])
+
+    # Runtime-typed tensor via the zeros() factory (canonical creation path).
+    var _a = zeros([2, 3], DType.float32)
+
+    print("projectodyssey package import test: OK")


### PR DESCRIPTION
## Summary

Adds the `projectodyssey` recipe so consumers can install ProjectOdyssey's
Mojo library via `pixi add projectodyssey` from the modular-community
channel.

- **Source**: https://github.com/HomericIntelligence/ProjectOdyssey (BSD-3-Clause)
- **Pinned to commit**: `c27b76b5e5c95fe8264ada0096b6f1a0dcc77f50`

The recipe builds with `mojo package -I src src/projectodyssey -o ${PREFIX}/lib/mojo/projectodyssey.mojopkg`
and includes a `tests:` block that imports and instantiates a Tensor and an
AnyTensor from the built `.mojopkg` to prove the package is importable.

## Test Plan

- [ ] `rattler-build build --recipe recipes/projectodyssey/recipe.yaml` succeeds
- [ ] The recipe's `tests:` block passes (smoke import)

Generated by `scripts/publish_modular_community.py` in ProjectOdyssey.
