### PR TITLE
Bump UUID package version

### DIFF
--- a/recipes/uuid/recipe.yaml
+++ b/recipes/uuid/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.0.0"
+  version: "1.1.0"
 
 package:
   name: uuid
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/lczerniawski/uuid.git
-    rev: 3e928b20ad4071de1bf84ec6666c09bd9dfc1514
+    rev: 77613ab60c9fcf73c848c5cdd1df5d1cc432ff3d
 
 build:
   number: 0
@@ -17,10 +17,13 @@ build:
 requirements:
   build:
     - mojo-compiler =1.0.0b1
+    - crypto =0.1.0
   host:
     - mojo-compiler =1.0.0b1
+    - crypto =0.1.0
   run:
     - ${{ pin_compatible('mojo-compiler') }}
+    - ${{ pin_compatible('crypto') }}
 
 tests:
   - script:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
