### PR TITLE
Add mojo-intel-gpu recipe

### DIFF
--- a/recipes/mojo-intel-gpu/recipe.yaml
+++ b/recipes/mojo-intel-gpu/recipe.yaml
@@ -1,0 +1,37 @@
+context:
+  version: "0.1.0"
+  mojo_version: "=1.0.0b1"
+
+package:
+  name: mojo-intel-gpu
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/andomeder/mojo-intel-gpu.git
+    rev: d0672d2b39d06ee67371308128c65ad46740ed30
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${PREFIX}/lib/mojo
+    - mojo package mojo_intel_gpu -o ${PREFIX}/lib/mojo/mojo_intel_gpu.mojopkg
+
+requirements:
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+about:
+  homepage: https://github.com/andomeder/mojo-intel-gpu
+  repository: https://github.com/andomeder/mojo-intel-gpu
+  license: MIT
+  license_file: LICENSE
+  summary: Level Zero FFI bindings and high-level API for Intel GPU compute in Mojo
+
+extra:
+  project_name: mojo-intel-gpu
+  maintainers:
+    - andomeder


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).