### PR TITLE
Update argmojo to v0.7.0 (Mojo v1.0.0b2)

### DIFF
--- a/recipes/argmojo/README.md
+++ b/recipes/argmojo/README.md
@@ -31,7 +31,7 @@ ArgMojo has been successfully deployed in production in [Decimo](https://github.
 
 ArgMojo provides two complementary styles for defining and parsing command-line arguments in Mojo: a **builder API** for maximum control (`Command` + `Argument` chains) and an optional **struct-based declarative API** inspired by Swift's [swift-argument-parser](https://github.com/apple/swift-argument-parser) (define a `Parsable` struct, call `MyArgs.parse()`, get typed results). You can mix both freely — put most of your arguments in a struct and drop down to builder methods whenever you need finer control.
 
-ArgMojo v0.6.0 targets Mojo v1.0.0b1.
+ArgMojo v0.7.0 targets Mojo v1.0.0b2.
 
 ArgMojo currently supports:
 

--- a/recipes/argmojo/recipe.yaml
+++ b/recipes/argmojo/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "0.6.0"
-  mojo_version: "=1.0.0b1"
+  version: "0.7.0"
+  mojo_version: "=1.0.0b2"
 
 package:
   name: "argmojo"
@@ -8,13 +8,13 @@ package:
 
 source:
   - git: https://github.com/forfudan/argmojo.git
-    rev: 47df395940e9f9048a4535c2531aeeedfb40a7ca
+    rev: 5e244891daa5c919d344a369f9577b21282f1587
 
 build:
   number: 0
   script:
     - mkdir -p ${PREFIX}/lib/mojo
-    - mojo package src/argmojo -o ${{ PREFIX }}/lib/mojo/argmojo.mojopkg
+    - mojo precompile src/argmojo -o ${{ PREFIX }}/lib/mojo/argmojo.mojoc
 
 requirements:
   host:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
