### PR TITLE
Add mtest 1.0.0

### DIFF
--- a/recipes/mtest/recipe.yaml
+++ b/recipes/mtest/recipe.yaml
@@ -1,0 +1,85 @@
+context:
+  version: "1.0.0"
+
+package:
+  name: mtest
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/mikeleppane/mtest.git
+    rev: b50ae9a29ef35dfc19ee724278d287e2cb2da286
+
+build:
+  number: 0
+  skip:
+    - linux and aarch64
+  files:
+    - bin/mtest
+    - share/mtest/companions/assertions/src/mtest/**
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        bash recipe/build.sh
+
+requirements:
+  build:
+    - mojo ==1.0.0b2
+    - clang ==18.1.8
+  host:
+    - mojo-compiler ==1.0.0b2
+  run:
+    - mojo-compiler ==1.0.0b2
+
+tests:
+  - files:
+      recipe:
+        - test_smoke.mojo
+    script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test "$(mtest --version)" = "mtest ${{ version }}"
+          mtest --help >/dev/null
+          mtest --no-config test_smoke.mojo
+          test -x "${PREFIX}/bin/mtest"
+          root="${PREFIX}/share/mtest/companions/assertions/src"
+          test -f "${root}/mtest/__init__.mojo"
+          test -f "${root}/mtest/assertions/__init__.mojo"
+          test -f "${root}/mtest/assertions/_display.mojo"
+          test -f "${root}/mtest/assertions/_mapping.mojo"
+          test -f "${root}/mtest/assertions/_sequence.mojo"
+          test -f "${root}/mtest/assertions/_text.mojo"
+          test -z "$(find "${root}" -type l -print)"
+          actual="$(
+            find "${root}" ! -type d -print |
+              sed "s#^${root}/##" |
+              LC_ALL=C sort
+          )"
+          expected="$(
+            printf '%s\n' \
+              mtest/__init__.mojo \
+              mtest/assertions/__init__.mojo \
+              mtest/assertions/_display.mojo \
+              mtest/assertions/_mapping.mojo \
+              mtest/assertions/_sequence.mojo \
+              mtest/assertions/_text.mojo
+          )"
+          test "${actual}" = "${expected}"
+  - package_contents:
+      bin:
+        - mtest
+
+about:
+  homepage: https://github.com/mikeleppane/mtest
+  repository: https://github.com/mikeleppane/mtest
+  license: MIT
+  license_file: LICENSE
+  summary: A pytest-like test runner for Mojo that orchestrates the stdlib's per-file TestSuite
+
+extra:
+  project_name: mtest
+  maintainers:
+    - mikeleppane

--- a/recipes/mtest/test_smoke.mojo
+++ b/recipes/mtest/test_smoke.mojo
@@ -1,0 +1,11 @@
+"""Public-package smoke fixture: one ordinary passing TestSuite file."""
+
+from std.testing import assert_equal, TestSuite
+
+
+def test_public_package_executes() raises:
+    assert_equal(2 + 2, 4)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
A pytest-like test runner for Mojo. mtest orchestrates the standard library's
per-file `TestSuite` rather than replacing it: it owns discovery, building,
supervised execution, cross-file test selection, and CI-shaped reporting
(including JUnit XML).

- **Source:** https://github.com/mikeleppane/mtest @ `b50ae9a`
- **Installs:** `bin/mtest` plus the assertion companion sources
- **Platforms:** `linux-64`, `osx-arm64`

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged) — n/a, new package

