### PR TITLE
Add mtest 1.1.0 build 0

### DIFF
--- a/recipes/mtest/recipe.yaml
+++ b/recipes/mtest/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.0.0"
+  version: "1.1.0"
 
 package:
   name: mtest
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/mikeleppane/mtest.git
-    rev: b50ae9a29ef35dfc19ee724278d287e2cb2da286
+    rev: 3b534933892f6bc20312c84fe5585a756ff99248
 
 build:
   number: 0


### PR DESCRIPTION
**Checklist**
- [ ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
