### PR TITLE
update kelvin to 0.3.0

### DIFF
--- a/recipes/kelvin/recipe.yaml
+++ b/recipes/kelvin/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: 0.2.1
+  version: 0.3.0
 
 package:
   name: "kelvin"
@@ -7,7 +7,7 @@ package:
 
 source:
  - git: https://github.com/bgreni/Kelvin.git
-   rev: 7e108b09cca5660ee168825e4a11e282df52a367
+   rev: 471409b4f1ac980be4beb5ba7de9a152d2e3f702
 
 build:
   number: 0
@@ -16,9 +16,9 @@ build:
 
 requirements:
   host:
-    - mojo-compiler =0.26.2
+    - mojo-compiler =1.0.0
   build:
-    - mojo-compiler =0.26.2
+    - mojo-compiler =1.0.0
   run:
     - ${{ pin_compatible('mojo-compiler') }}
 
@@ -38,9 +38,9 @@ tests:
         - scripts/generate_tests.py
     requirements:
       build:
-        - mojo =0.26.2
+        - mojo =1.0.0
       run:
-        - mojo =0.26.2
+        - mojo =1.0.0
 
 about:
   homepage: https://github.com/bgreni/Kelvin


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
