### PR TITLE
Update mojo-intel-gpu to v0.2.0 (Mojo 1.0.0)

### DIFF
--- a/recipes/mojo-intel-gpu/recipe.yaml
+++ b/recipes/mojo-intel-gpu/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "0.1.0"
-  mojo_version: "=1.0.0b1"
+  version: "0.2.0"
+  mojo_version: "=1.0.0"
 
 package:
   name: mojo-intel-gpu
@@ -8,13 +8,13 @@ package:
 
 source:
   - git: https://github.com/andomeder/mojo-intel-gpu.git
-    rev: d0672d2b39d06ee67371308128c65ad46740ed30
+    rev: d3936acd5b3802e622b5f222982af57c8a0515f3
 
 build:
   number: 0
   script:
     - mkdir -p ${PREFIX}/lib/mojo
-    - mojo package mojo_intel_gpu -o ${PREFIX}/lib/mojo/mojo_intel_gpu.mojopkg
+    - mojo precompile mojo_intel_gpu -o ${PREFIX}/lib/mojo/mojo_intel_gpu.mojoc
 
 requirements:
   host:


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
