### PR TITLE
A Hotfix for Mojmelo

### DIFF
--- a/recipes/mojmelo/recipe.yaml
+++ b/recipes/mojmelo/recipe.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
   - git: https://github.com/yetalit/mojmelo.git
-    rev: 4273e5cb6385a5a045f429dc9fe5c82753d3721a
+    rev: 3ea2468262f11ae918f69e6337174a078fa9d3a4
 
 build:
-  number: 0
+  number: 1
   script:
     - mojo precompile pixi/mojmelo/utils/mojmelo_matmul -o ${{ PREFIX }}/lib/mojo/mojmelo_matmul.mojoc
     - mojo precompile pixi/mojmelo -o ${{ PREFIX }}/lib/mojo/mojmelo.mojoc


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
