### PR TITLE
chore: add mojopt 0.4.0

### DIFF
--- a/recipes/mojopt/recipe.yaml
+++ b/recipes/mojopt/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: "0.4.0"
+  mojo_version: "=1.0.0"
+
+package:
+  name: "mojopt"
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/sstadick/mojopt.git
+    rev: ab4c985b3a6e944b934d55b3dee12a1b8f64b0b2
+
+build:
+  number: 0
+  script:
+    - mkdir -p "${PREFIX}/lib/mojo"
+    - mojo precompile mojopt -o "${PREFIX}/lib/mojo/mojopt.mojoc"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - |
+            set -u
+            target_features=""
+            if [ "$(uname -m)" = "x86_64" ]; then
+              # GitHub AMD runners can select AVX-512 features that the host
+              # does not expose.
+              target_features="--target-features=-avx512f,-avx512bw,-avx512cd,-avx512dq,-avx512vl,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq,-avx512fp16,-avx512bf16"
+            fi
+            for test in $(find ./tests -name 'test_*.mojo' | sort); do
+              echo "Running ${test} with mojo run"
+              mojo run ${target_features} -debug-level=line-tables -I "${PREFIX}/lib/mojo" -D ASSERT=all "${test}" || exit $?
+            done
+    requirements:
+      build:
+        - mojo ${{ mojo_version }}
+      run:
+        - mojo ${{ mojo_version }}
+    files:
+      source:
+        - tests/
+
+about:
+  homepage: https://github.com/sstadick/mojopt
+  license: "Unlicense OR MIT"
+  license_file:
+    - LICENSE-MIT
+    - UNLICENSE
+  summary: A Mojo library for parsing CLI arguments using struct definitions.
+  repository: https://github.com/sstadick/mojopt
+
+extra:
+  maintainers:
+    - sstadick
+  project_name: mojopt


### PR DESCRIPTION
Adds Mojopt v0.4.0 to Modular Community for the stable Mojo 1.0.0 release.

**Checklist**

- [x] My `recipe.yaml` specifies the compatible Mojo/MAX version (`mojo = 1.0.0`).
- [x] License files are packaged (`LICENSE-MIT` and `UNLICENSE`).
- [x] Set the build number to `0` because this is a new package.
- [ ] Bumped the build number for an unchanged version (not applicable; this is a new package).
