### PR TITLE
Add morrow 0.7.0

### DIFF
--- a/recipes/morrow/recipe.yaml
+++ b/recipes/morrow/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  version: "0.7.0"
+
+package:
+  name: morrow
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/mojoto/morrow.mojo.git
+    rev: 7562c4c6e93e63d228881fb9feba0c548ad90814
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${PREFIX}/lib/mojo
+    - mojo precompile morrow -o ${PREFIX}/lib/mojo/morrow.mojoc
+
+requirements:
+  build:
+    - mojo-compiler =1.0.0
+  host:
+    - mojo-compiler =1.0.0
+  run:
+    - mojo-compiler >=1.0.0,<1.1.0
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run test.mojo
+    files:
+      recipe:
+        - test.mojo
+
+about:
+  homepage: https://github.com/mojoto/morrow.mojo
+  repository: https://github.com/mojoto/morrow.mojo
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Human-friendly date and time utilities for Mojo.
+
+extra:
+  project_name: Morrow
+  maintainers:
+    - Prodesire

--- a/recipes/morrow/test.mojo
+++ b/recipes/morrow/test.mojo
@@ -1,0 +1,10 @@
+from std.testing import assert_equal
+
+from morrow import Morrow
+
+
+def main() raises:
+    var value = Morrow.get("2026-01-01T03:04:05Z")
+    assert_equal(
+        value.format("YYYY-MM-DD HH:mm:ss ZZ"), "2026-01-01 03:04:05 +00:00"
+    )


### PR DESCRIPTION
Adds [Morrow](https://github.com/mojoto/morrow.mojo) 0.7.0, a human-friendly date and time library for Mojo.

Validation:
- Built successfully with `rattler-build` on macOS ARM64
- Installed and tested the generated Conda package in an isolated environment
- Upstream CI passes on Linux x86-64, Linux ARM64, and macOS ARM64

**Checklist**
- [x] `recipe.yaml` specifies Mojo compatibility (`>=1.0.0,<1.1.0`).
- [x] License file is packaged.
- [x] Build number is set to `0` for the new package.
- [x] Build-number bump is not applicable because this is a new package.