### PR TITLE
Add safetensors-mojo 0.5.0

### DIFF
--- a/recipes/safetensors-mojo/recipe.yaml
+++ b/recipes/safetensors-mojo/recipe.yaml
@@ -1,0 +1,50 @@
+context:
+  version: "0.5.0"
+
+package:
+  name: safetensors-mojo
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/egor-fedorov/safetensors.mojo.git
+    rev: 1dd3450d02a39b4b8b5cfee01e82c88743bec72b
+
+build:
+  number: 0
+  skip:
+    - osx
+    - linux and aarch64
+  script:
+    - mkdir -p "${PREFIX}/lib/mojo"
+    - mojo precompile src/safetensors -o "${PREFIX}/lib/mojo/safetensors.mojoc"
+    - rm -f "${PREFIX}/share/max/firstActivation"
+
+requirements:
+  build:
+    - mojo-compiler =1.0.0
+  host:
+    - mojo-compiler =1.0.0
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - test -f "${PREFIX}/lib/mojo/safetensors.mojoc"
+          - mojo run test_package.mojo
+    files:
+      recipe:
+        - test_package.mojo
+
+about:
+  homepage: https://github.com/egor-fedorov/safetensors.mojo
+  repository: https://github.com/egor-fedorov/safetensors.mojo
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: An independent Safetensors format implementation for Mojo with checked validation
+
+extra:
+  maintainers:
+    - egor-fedorov
+  project_name: safetensors.mojo

--- a/recipes/safetensors-mojo/test_package.mojo
+++ b/recipes/safetensors-mojo/test_package.mojo
@@ -1,0 +1,39 @@
+"""Smoke test for the installed safetensors-mojo Conda package."""
+
+from std.testing import assert_equal, assert_true
+
+from safetensors import SafeDType, decode_header_length, parse_metadata
+
+
+def main() raises:
+    var header = '{"tensor":{"dtype":"U8","shape":[2],"data_offsets":[0,2]}}'
+    var header_length = UInt64(header.byte_length())
+    var contents = List[UInt8]()
+
+    for index in range(8):
+        contents.append(
+            UInt8((header_length >> UInt64(index * 8)) & UInt64(0xFF))
+        )
+    for byte in header.as_bytes():
+        contents.append(byte)
+    contents.append(17)
+    contents.append(29)
+
+    assert_equal(decode_header_length(contents), header_length)
+
+    var metadata = parse_metadata(contents)
+    assert_equal(len(metadata), 1)
+    assert_true(metadata.contains("tensor"))
+    assert_equal(metadata.data_length(), UInt64(2))
+
+    var tensor = metadata.info("tensor")
+    assert_equal(tensor.dtype, SafeDType.U8)
+    assert_equal(len(tensor.shape), 1)
+    assert_equal(tensor.shape[0], UInt64(2))
+    assert_equal(tensor.begin, UInt64(0))
+    assert_equal(tensor.end, UInt64(2))
+    assert_equal(tensor.element_count, UInt64(2))
+    assert_equal(tensor.bit_length, UInt64(16))
+    assert_equal(tensor.byte_length, UInt64(2))
+
+    print("safetensors-mojo installed-package smoke test passed")


### PR DESCRIPTION
## Summary

Add `safetensors-mojo` 0.5.0, an independent Safetensors format implementation for Mojo.

- Pin the source to the immutable commit behind the annotated `v0.5.0` tag.
- Precompile the importable `safetensors` package with Mojo 1.0.0.
- Publish for `linux-64`; unsupported macOS and Linux AArch64 builds are skipped.
- Exercise the installed package with a format-core smoke test.

## Validation

- `pixi run lint`
- Recipe validation against the pinned official recipe-format schema
- Clean `rattler-build` build for `linux-64`
- Installed-package test against the resulting Conda artifact
- Render checks confirming that `osx-arm64` and `linux-aarch64` are skipped
- Artifact inspection confirming the expected `.mojoc`, test, metadata, and license payload

The source repository also has GitHub CodeQL default setup enabled for Python and GitHub Actions; its initial scans completed successfully with no open alerts.

## Checklist

- [x] MAX compatibility is not applicable: this package has no MAX dependency. It builds with Mojo 1.0.0 and declares a pin-compatible Mojo compiler runtime.
- [x] The Apache-2.0 license file is packaged.
- [x] The build number is `0` for this new package.
- [x] A build-number bump is not applicable because this is the initial recipe.
