### PR TITLE
Add mojo-net, protomojo, mojo-tls, mojo-http2, and grpc-mojo

### DIFF
--- a/recipes/grpc-mojo/recipe.yaml
+++ b/recipes/grpc-mojo/recipe.yaml
@@ -1,0 +1,89 @@
+context:
+  version: "0.2.2"
+  mojo_version: ">=1.0.0,<1.1.0"
+  family_version: ">=0.2.0,<0.3.0"
+  protomojo_version: ">=0.4.0,<0.5.0"
+  tls_version: ">=0.3.0,<0.4.0"
+
+package:
+  name: grpc-mojo
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/grpc-mojo.git
+    rev: 2aee07fdd64a82745f368414f244f4efb664730c
+
+build:
+  number: 0
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        mkdir -p "${PREFIX}/lib/mojo"
+        mojo precompile -I "${PREFIX}/lib/mojo" src/grpc \
+          -o "${PREFIX}/lib/mojo/grpc.mojoc"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-http2 ${{ family_version }}
+    - mojo-net ${{ family_version }}
+    - mojo-tls ${{ tls_version }}
+    - protomojo ${{ protomojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-http2 ${{ family_version }}
+    - mojo-net ${{ family_version }}
+    - mojo-tls ${{ tls_version }}
+    - protomojo ${{ protomojo_version }}
+
+tests:
+  - script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/grpc.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/grpc.mojopkg"
+          test -f "${PREFIX}/lib/mojo/h2.mojoc"
+          test -f "${PREFIX}/lib/mojo/hpack.mojoc"
+          test -f "${PREFIX}/lib/mojo/net.mojoc"
+          test -f "${PREFIX}/lib/mojo/proto.mojoc"
+          test -f "${PREFIX}/lib/mojo/tls.mojoc"
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          SMOKE="${PWD}/tests/package_smoke.mojo"
+          MOJO="${PREFIX}/bin/mojo"
+          test -x "${MOJO}"
+          cd "${WORK}"
+          export CONDA_PREFIX="${PREFIX}"
+          export MODULAR_HOME="${PREFIX}/share/max"
+          export PATH="${PREFIX}/bin:${PATH}"
+          unset MOJO_PATH MOJO_TLS_SHIM
+          if [ "$(uname -s)" = Linux ]; then
+            "${MOJO}" build --emit object "${SMOKE}" -o package_smoke.o
+            test -s package_smoke.o
+            "${MOJO}" run "${SMOKE}"
+          else
+            "${MOJO}" build "${SMOKE}" -o package_smoke
+            ./package_smoke
+          fi
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/grpc-mojo
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: gRPC client and server runtime for Mojo
+  repository: https://github.com/nsalerni/grpc-mojo
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: grpc-mojo

--- a/recipes/grpc-mojo/tests/package_smoke.mojo
+++ b/recipes/grpc-mojo/tests/package_smoke.mojo
@@ -1,0 +1,154 @@
+from std.testing import assert_equal, assert_true
+
+from grpc import (
+    GrpcChannel,
+    Metadata,
+    PollingServer,
+    PollingServerConfig,
+    Server,
+    ServerContext,
+    Status,
+    StatusCode,
+    decode_timeout,
+    encode_timeout,
+    frame_message,
+    status_code_name,
+)
+from net import resolve
+from proto import ProtoMessage, WireReader, WireWriter, decode, encode
+from tls import PeerCertificate, SubjectAlternativeNames, TLSContext
+
+
+struct PackageMessage(Copyable, Defaultable, Movable, ProtoMessage):
+    var value: String
+    var _unknown: List[Byte]
+
+    def __init__(out self):
+        self.value = String()
+        self._unknown = List[Byte]()
+
+    def __init__(out self, var value: String):
+        self.value = value^
+        self._unknown = List[Byte]()
+
+    def encode_to(self, mut writer: WireWriter):
+        if self.value.byte_length() != 0:
+            writer.string_field(1, self.value)
+        writer.buf.extend(Span(self._unknown))
+
+    def merge_from(mut self, mut reader: WireReader) raises:
+        while not reader.done():
+            var tag = reader.read_tag()
+            if tag[0] == 1:
+                self.value = reader.string_value()
+            else:
+                reader.capture_field(tag[0], tag[1], self._unknown)
+
+
+def _check_client_identity_api() raises:
+    """Type-checks the installed channel API without opening a connection."""
+    _ = GrpcChannel.connect_tls(
+        "localhost",
+        443,
+        cert_chain_pem="client-chain.pem",
+        key_pem="client.key",
+    )
+
+
+def _check_server_identity_api() raises:
+    """Type-checks required client authentication without binding."""
+    _ = Server.tls(
+        "127.0.0.1",
+        443,
+        "server-chain.pem",
+        "server.key",
+        client_ca_file="client-ca.pem",
+        require_client_cert=True,
+    )
+
+
+def _check_polling_server_identity_api() raises:
+    """Type-checks polling server client authentication without binding."""
+    _ = PollingServer.tls(
+        "127.0.0.1",
+        443,
+        "server-chain.pem",
+        "server.key",
+        PollingServerConfig(),
+        client_ca_file="client-ca.pem",
+        require_client_cert=True,
+    )
+
+
+def _check_peer_certificate_api() raises:
+    """Type-checks the owned client identity exposed to handlers."""
+    var unauthenticated = ServerContext()
+    assert_true(not unauthenticated.peer_certificate)
+
+    var der: List[Byte] = [0x30, 0x00]
+    var certificate = PeerCertificate(
+        leaf_der=der^,
+        verified=True,
+        matched_name=String(),
+        subject_alt_names=SubjectAlternativeNames(
+            dns_names=["client.example.test"],
+            uri_names=["spiffe://example.test/client"],
+            email_addresses=["client@example.test"],
+            ip_addresses=["192.0.2.44", "2001:db8::44"],
+        ),
+    )
+    var peer: Optional[PeerCertificate] = certificate^
+    var authenticated = ServerContext(peer)
+    assert_true(authenticated.peer_certificate)
+    assert_true(authenticated.peer_certificate.value().verified)
+    assert_equal(len(authenticated.peer_certificate.value().leaf_der), 2)
+    assert_equal(
+        authenticated.peer_certificate.value().subject_alt_names.dns_names[0],
+        "client.example.test",
+    )
+    assert_equal(
+        authenticated.peer_certificate.value().subject_alt_names.uri_names[0],
+        "spiffe://example.test/client",
+    )
+    assert_equal(
+        authenticated.peer_certificate.value().subject_alt_names.email_addresses[
+            0
+        ],
+        "client@example.test",
+    )
+    assert_equal(
+        authenticated.peer_certificate.value().subject_alt_names.ip_addresses[
+            1
+        ],
+        "2001:db8::44",
+    )
+
+
+def main() raises:
+    assert_true(Status.ok().is_ok())
+    assert_equal(
+        String(status_code_name(StatusCode.UNAVAILABLE)), "UNAVAILABLE"
+    )
+    assert_equal(encode_timeout(1_500), "1500n")
+    assert_equal(decode_timeout("2m"), 2_000_000)
+
+    var encoded = encode(PackageMessage(value="installed"))
+    var decoded = decode[PackageMessage](Span(encoded))
+    assert_equal(decoded.value, "installed")
+
+    var framed = frame_message(Span(encoded))
+    assert_equal(len(framed), len(encoded) + 5)
+    assert_equal(framed[0], 0)
+
+    var metadata = Metadata()
+    metadata.add("x-package", "installed")
+    assert_equal(metadata.get("x-package").value(), "installed")
+    assert_equal(len(metadata.entries), 1)
+
+    var addresses = resolve("127.0.0.1", 443)
+    assert_true(len(addresses) >= 1)
+    assert_equal(addresses[0].port, 443)
+
+    _ = TLSContext.client(verify=False, alpn=["h2"])
+    _check_peer_certificate_api()
+    print("grpc-mojo package smoke test passed")

--- a/recipes/mojo-http2/recipe.yaml
+++ b/recipes/mojo-http2/recipe.yaml
@@ -1,0 +1,82 @@
+context:
+  version: "0.2.7"
+  mojo_version: ">=1.0.0,<1.1.0"
+  mojo_net_version: ">=0.2.4,<0.3.0"
+  mojo_tls_version: ">=0.2.0,<0.4.0"
+
+package:
+  name: mojo-http2
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/mojo-http2.git
+    rev: 4aed60e49715a0b3bf9776daa99f3038411babea
+
+build:
+  number: 0
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        mkdir -p "${PREFIX}/lib/mojo"
+        mojo precompile src/hpack \
+          -o "${PREFIX}/lib/mojo/hpack.mojoc"
+        mojo precompile -I "${PREFIX}/lib/mojo" src/h2 \
+          -o "${PREFIX}/lib/mojo/h2.mojoc"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - mojo-tls ${{ mojo_tls_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - mojo-tls ${{ mojo_tls_version }}
+
+tests:
+  - script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/hpack.mojoc"
+          test -f "${PREFIX}/lib/mojo/h2.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/hpack.mojopkg"
+          test ! -e "${PREFIX}/lib/mojo/h2.mojopkg"
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          SMOKE="${PWD}/tests/package_smoke.mojo"
+          MOJO="${PREFIX}/bin/mojo"
+          test -x "${MOJO}"
+          cd "${WORK}"
+          export CONDA_PREFIX="${PREFIX}"
+          export MODULAR_HOME="${PREFIX}/share/max"
+          export PATH="${PREFIX}/bin:${PATH}"
+          if [ "$(uname -s)" = Linux ]; then
+            "${MOJO}" build --emit object "${SMOKE}" -o package_smoke.o
+            test -s package_smoke.o
+            "${MOJO}" run "${SMOKE}"
+          else
+            "${MOJO}" build "${SMOKE}" -o package_smoke
+            ./package_smoke
+          fi
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/mojo-http2
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: HPACK and HTTP/2 with h2c and TLS transports for Mojo
+  repository: https://github.com/nsalerni/mojo-http2
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: mojo-http2

--- a/recipes/mojo-http2/tests/package_smoke.mojo
+++ b/recipes/mojo-http2/tests/package_smoke.mojo
@@ -1,0 +1,30 @@
+from std.testing import assert_equal
+
+from h2 import H2_ALPN, FrameHeader
+from hpack import Decoder, HeaderField
+
+
+def main() raises:
+    var header = FrameHeader(
+        length=1024, frame_type=0x1, flags=0x5, stream_id=7
+    )
+    var wire = List[Byte]()
+    header.serialize(wire)
+    var parsed = FrameHeader.parse(Span(wire))
+    assert_equal(parsed.length, 1024)
+    assert_equal(parsed.frame_type, 0x1)
+    assert_equal(parsed.flags, 0x5)
+    assert_equal(parsed.stream_id, 7)
+
+    var block = List[Byte]()
+    block.append(0x82)
+    block.append(0x86)
+    block.append(0x84)
+    var decoder = Decoder()
+    var fields = decoder.decode(Span(block))
+    assert_equal(len(fields), 3)
+    assert_equal(fields[0], HeaderField(name=":method", value="GET"))
+    assert_equal(fields[1], HeaderField(name=":scheme", value="http"))
+    assert_equal(fields[2], HeaderField(name=":path", value="/"))
+    assert_equal(String(H2_ALPN), "h2")
+    print("installed mojo-http2 package smoke test passed")

--- a/recipes/mojo-net/recipe.yaml
+++ b/recipes/mojo-net/recipe.yaml
@@ -1,0 +1,55 @@
+context:
+  version: "0.2.4"
+  mojo_version: ">=1.0.0,<1.1.0"
+
+package:
+  name: mojo-net
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/mojo-net.git
+    rev: 2bb696e053c691df8e59f9ffd77a92603e374395
+
+build:
+  number: 0
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        mkdir -p "${PREFIX}/lib/mojo"
+        mojo precompile src/net -o "${PREFIX}/lib/mojo/net.mojoc"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+tests:
+  - script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/net.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/net.mojopkg"
+          mojo build tests/package_smoke.mojo -o package_smoke
+          ./package_smoke
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/mojo-net
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: TCP, UDP, DNS, Unix sockets, and readiness polling for Mojo
+  repository: https://github.com/nsalerni/mojo-net
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: mojo-net

--- a/recipes/mojo-net/tests/package_smoke.mojo
+++ b/recipes/mojo-net/tests/package_smoke.mojo
@@ -1,0 +1,38 @@
+from net import (
+    IPv4Address,
+    Poller,
+    TCPListener,
+    TCPStream,
+    is_would_block,
+)
+
+
+def main() raises:
+    var address = IPv4Address("127.0.0.1", 443)
+    if address.port != 443:
+        raise Error("installed mojo-net package returned the wrong port")
+
+    var listener = TCPListener("127.0.0.1", 0)
+    listener.set_nonblocking(True)
+    var poller = Poller()
+    poller.register(listener.descriptor(), readable=True, writable=False)
+    var client = TCPStream.connect("127.0.0.1", listener.local_port)
+    if len(poller.wait(5000)) == 0:
+        raise Error("installed listener did not become readable")
+    var accepted = listener.accept()
+    if not accepted.nonblocking:
+        raise Error("accepted stream did not inherit non-blocking mode")
+    var blocked = False
+    try:
+        _ = accepted.read_exact(1)
+    except e:
+        if not is_would_block(e):
+            raise e
+        blocked = True
+    if not blocked:
+        raise Error("empty accepted stream did not report would-block")
+    client.close()
+    accepted.close()
+    poller.close()
+    listener.close()
+    print("mojo-net package smoke test passed")

--- a/recipes/mojo-tls/recipe.yaml
+++ b/recipes/mojo-tls/recipe.yaml
@@ -1,0 +1,170 @@
+context:
+  version: "0.3.0"
+  mojo_version: ">=1.0.0,<1.1.0"
+  mojo_net_version: ">=0.2.1,<0.3.0"
+  openssl_version: ">=3.0,<4.0a0"
+
+package:
+  name: mojo-tls
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/mojo-tls.git
+    rev: 5c578bd556c64810aec5fa60652780e25570ab4c
+
+build:
+  number: 0
+  dynamic_linking:
+    # The shim sets platform-native relative loader paths below.
+    binary_relocation: false
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        : "${CC:?the package build must provide a C compiler}"
+        mkdir -p "${PREFIX}/lib" "${PREFIX}/lib/mojo"
+
+        case "$(uname -s)" in
+          Darwin)
+            "${CC}" -dynamiclib -fPIC -O2 -Wall -Werror \
+              -I"${PREFIX}/include" \
+              -L"${PREFIX}/lib" \
+              -Wl,-rpath,@loader_path \
+              -Wl,-install_name,@rpath/libmojotls.dylib \
+              -o "${PREFIX}/lib/libmojotls.dylib" \
+              shim/mojotls_shim.c -lssl -lcrypto
+            ;;
+          *)
+            "${CC}" -shared -fPIC -O2 -Wall -Werror -pthread \
+              -I"${PREFIX}/include" \
+              -L"${PREFIX}/lib" \
+              -Wl,-rpath,'$ORIGIN' \
+              -Wl,-soname,libmojotls.so \
+              -o "${PREFIX}/lib/libmojotls.so" \
+              shim/mojotls_shim.c -lssl -lcrypto
+            patchelf --set-rpath '$ORIGIN' "${PREFIX}/lib/libmojotls.so"
+            ;;
+        esac
+
+        mojo precompile -I "${PREFIX}/lib/mojo" src/tls \
+          -o "${PREFIX}/lib/mojo/tls.mojoc"
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - mojo-compiler ${{ mojo_version }}
+    - if: linux
+      then: patchelf
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - openssl ${{ openssl_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - openssl ${{ openssl_version }}
+
+tests:
+  - requirements:
+      run:
+        - if: linux
+          then: binutils
+    script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/tls.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/tls.mojopkg"
+
+          case "$(uname -s)" in
+            Darwin)
+              SHIM="${PREFIX}/lib/libmojotls.dylib"
+              test -f "${SHIM}"
+              RPATHS="$(otool -l "${SHIM}" | awk \
+                '$1 == "cmd" && $2 == "LC_RPATH" { getline; getline; print $2 }')"
+              test "${RPATHS}" = '@loader_path'
+              otool -D "${SHIM}" | grep -F '@rpath/libmojotls.dylib'
+              otool -L "${SHIM}" | grep -F '@rpath/libssl.3.dylib'
+              otool -L "${SHIM}" | grep -F '@rpath/libcrypto.3.dylib'
+              ;;
+            *)
+              SHIM="${PREFIX}/lib/libmojotls.so"
+              test -f "${SHIM}"
+              readelf -d "${SHIM}" | \
+                grep -E '\((RPATH|RUNPATH)\).*\[\$ORIGIN\]$'
+              readelf -d "${SHIM}" | grep -F '(SONAME)' | grep -F 'libmojotls.so'
+              readelf -d "${SHIM}" | grep -F '(NEEDED)' | grep -F 'libssl.so.3'
+              readelf -d "${SHIM}" | grep -F '(NEEDED)' | grep -F 'libcrypto.so.3'
+              ;;
+          esac
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=mojo-tls package CA' \
+            -addext 'basicConstraints=critical,CA:TRUE' \
+            -addext 'keyUsage=critical,keyCertSign,cRLSign' \
+            -keyout "${WORK}/ca.key" -out "${WORK}/ca.pem" -days 1 \
+            >/dev/null 2>&1
+          openssl req -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=localhost' \
+            -keyout "${WORK}/server.key" -out "${WORK}/server.csr" \
+            >/dev/null 2>&1
+          printf '%s\n' \
+            'subjectAltName=DNS:localhost,IP:127.0.0.1,URI:spiffe://example.test/package-server,email:server@example.test' \
+            'keyUsage=critical,digitalSignature,keyEncipherment' \
+            'extendedKeyUsage=serverAuth' 'basicConstraints=CA:FALSE' \
+            > "${WORK}/server.ext"
+          openssl x509 -req -sha256 -in "${WORK}/server.csr" \
+            -CA "${WORK}/ca.pem" -CAkey "${WORK}/ca.key" -CAcreateserial \
+            -extfile "${WORK}/server.ext" \
+            -out "${WORK}/server.pem" -days 1 >/dev/null 2>&1
+          openssl req -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=mojo-tls package client' \
+            -keyout "${WORK}/client.key" -out "${WORK}/client.csr" \
+            >/dev/null 2>&1
+          printf '%s\n' \
+            'subjectAltName=DNS:client.example.test,IP:192.0.2.45,URI:spiffe://example.test/package-client,email:client@example.test' \
+            'keyUsage=critical,digitalSignature,keyEncipherment' \
+            'extendedKeyUsage=clientAuth' 'basicConstraints=CA:FALSE' \
+            > "${WORK}/client.ext"
+          openssl x509 -req -sha256 -in "${WORK}/client.csr" \
+            -CA "${WORK}/ca.pem" -CAkey "${WORK}/ca.key" -CAcreateserial \
+            -extfile "${WORK}/client.ext" \
+            -out "${WORK}/client.pem" -days 1 >/dev/null 2>&1
+
+          SMOKE="${PWD}/tests/package_smoke.mojo"
+          MOJO="${PREFIX}/bin/mojo"
+          test -x "${MOJO}"
+          cd "${WORK}"
+          export CONDA_PREFIX="${PREFIX}"
+          export MODULAR_HOME="${PREFIX}/share/max"
+          export PATH="${PREFIX}/bin:${PATH}"
+          unset MOJO_TLS_SHIM
+          test -z "${MOJO_TLS_SHIM:-}"
+          if [ "$(uname -s)" = Linux ]; then
+            "${MOJO}" build --emit object "${SMOKE}" -o package_smoke.o
+            test -s package_smoke.o
+            "${MOJO}" run "${SMOKE}" ca.pem server.pem server.key \
+              client.pem client.key
+          else
+            "${MOJO}" build "${SMOKE}" -o package_smoke
+            ./package_smoke ca.pem server.pem server.key client.pem client.key
+          fi
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/mojo-tls
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Strict TLS 1.2 and TLS 1.3 streams for Mojo
+  repository: https://github.com/nsalerni/mojo-tls
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: mojo-tls

--- a/recipes/mojo-tls/tests/package_smoke.mojo
+++ b/recipes/mojo-tls/tests/package_smoke.mojo
@@ -1,0 +1,117 @@
+from std.ffi import c_int, external_call
+from std.sys import argv
+from std.testing import assert_equal, assert_true
+
+from net import TCPListener, TCPStream
+from tls import PeerCertificate, SubjectAlternativeNames, TLSContext
+
+
+def run_server(
+    cert: String, key: String, client_ca: String
+) raises -> Tuple[UInt16, c_int]:
+    var listener = TCPListener("127.0.0.1", 0)
+    var port = listener.local_port
+    var pid = external_call["fork", c_int]()
+    if pid == 0:
+        try:
+            var context = TLSContext.server(
+                cert,
+                key,
+                client_ca_file=client_ca,
+                require_client_cert=True,
+                alpn=["h2"],
+            )
+            var tcp = listener.accept()
+            var stream = context.accept(tcp^)
+            var peer = stream.peer_certificate()
+            if not peer:
+                raise Error("installed server did not receive client identity")
+            var identity: PeerCertificate = peer.value().copy()
+            if not identity.verified or len(identity.leaf_der) == 0:
+                raise Error("installed server did not verify client identity")
+            if identity.matched_name != "":
+                raise Error("server client identity had a matched hostname")
+            var client_names: SubjectAlternativeNames = (
+                identity.subject_alt_names.copy()
+            )
+            if (
+                len(client_names.dns_names) != 1
+                or client_names.dns_names[0] != "client.example.test"
+                or client_names.uri_names[0]
+                != "spiffe://example.test/package-client"
+                or client_names.email_addresses[0] != "client@example.test"
+                or client_names.ip_addresses[0] != "192.0.2.45"
+            ):
+                raise Error("installed server copied wrong client names")
+            var request = stream.read_exact(4)
+            stream.write_all(Span(request))
+            stream.close()
+        except:
+            external_call["_exit", NoneType](c_int(1))
+        external_call["_exit", NoneType](c_int(0))
+    listener.close()
+    return (port, pid)
+
+
+def main() raises:
+    var args = argv()
+    assert_equal(
+        len(args),
+        6,
+        "expected CA, server identity, and client identity paths",
+    )
+
+    var compatibility_der = List[Byte](length=1, fill=0x30)
+    var compatibility = PeerCertificate(
+        compatibility_der^, False, String("legacy.example")
+    )
+    assert_equal(compatibility.matched_name, "legacy.example")
+    assert_equal(len(compatibility.subject_alt_names.dns_names), 0)
+
+    var server = run_server(
+        String(args[2]), String(args[3]), String(args[1])
+    )
+    var context = TLSContext.client(
+        ca_file=String(args[1]),
+        cert_chain_pem=String(args[4]),
+        key_pem=String(args[5]),
+        alpn=["h2"],
+    )
+    var tcp = TCPStream.connect("127.0.0.1", server[0])
+    var stream = context.connect(tcp^, "localhost")
+    var peer = stream.peer_certificate()
+    if not peer:
+        raise Error("installed client did not receive server identity")
+    var identity: PeerCertificate = peer.value().copy()
+    assert_true(identity.verified)
+    assert_true(len(identity.leaf_der) > 0)
+    assert_equal(identity.matched_name, "localhost")
+    assert_equal(identity.subject_alt_names.dns_names[0], "localhost")
+    assert_equal(
+        identity.subject_alt_names.uri_names[0],
+        "spiffe://example.test/package-server",
+    )
+    assert_equal(
+        identity.subject_alt_names.email_addresses[0],
+        "server@example.test",
+    )
+    assert_equal(identity.subject_alt_names.ip_addresses[0], "127.0.0.1")
+
+    assert_true(stream.version().startswith("TLSv1."), stream.version())
+    assert_equal(stream.negotiated_alpn(), "h2")
+    stream.write_all("ping".as_bytes())
+    assert_equal(String(from_utf8=stream.read_exact(4)), "ping")
+    stream.close()
+    assert_true(len(identity.leaf_der) > 0)
+    assert_equal(
+        identity.subject_alt_names.uri_names[0],
+        "spiffe://example.test/package-server",
+    )
+
+    var status = c_int(0)
+    var waited = external_call["waitpid", c_int](
+        server[1], Pointer(to=status), c_int(0)
+    )
+    assert_equal(waited, server[1], "waitpid failed")
+    assert_equal(status, 0, "TLS server failed")
+    print("installed mojo-tls package handshake passed")

--- a/recipes/protomojo/recipe.yaml
+++ b/recipes/protomojo/recipe.yaml
@@ -1,0 +1,61 @@
+context:
+  version: "0.4.0"
+  mojo_version: ">=1.0.0,<1.1.0"
+
+package:
+  name: protomojo
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/protomojo.git
+    rev: 734f2812d06f0205075861e9e9f709aa94198848
+
+build:
+  number: 0
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        mkdir -p "${PREFIX}/bin" "${PREFIX}/lib/mojo"
+        mojo precompile src/proto -o "${PREFIX}/lib/mojo/proto.mojoc"
+        install -m 0755 tools/protoc-gen-mojo "${PREFIX}/bin/protoc-gen-mojo"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - libprotobuf
+    - mojo-compiler ${{ mojo_version }}
+    - python >=3.11
+    - protobuf >=4.25
+
+tests:
+  - script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          command -v protoc-gen-mojo
+          command -v protoc
+          protoc --mojo_out=tests tests/package_smoke.proto
+          mojo build -I tests tests/package_smoke.mojo -o package_smoke
+          ./package_smoke
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+        - tests/package_smoke.proto
+
+about:
+  homepage: https://github.com/nsalerni/protomojo
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Protocol Buffers runtime and protoc plugin for Mojo
+  repository: https://github.com/nsalerni/protomojo
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: protomojo

--- a/recipes/protomojo/tests/package_smoke.mojo
+++ b/recipes/protomojo/tests/package_smoke.mojo
@@ -1,0 +1,56 @@
+from std.testing import assert_equal
+
+from any_pb import Any
+from package_smoke_pb import PackagePayload, PackageSmoke, SmokeState
+from package_smoke_pb_json_resolver import json_type_resolver
+from proto import (
+    JsonParseOptions,
+    JsonPrintOptions,
+    decode,
+    decode_json,
+    encode,
+    encode_json,
+)
+
+
+def main() raises:
+    var sent = PackageSmoke()
+    sent.request_id = 42
+    sent.payload = "installed package"
+    sent.state = SmokeState(value=SmokeState.SMOKE_STATE_READY)
+    var payload = PackagePayload()
+    payload.note = "resolved from installed codegen"
+    var metadata = Any()
+    metadata.type_url = "type.googleapis.com/PackagePayload"
+    metadata.value = encode(payload)
+    sent.metadata = metadata^
+
+    var received = decode[PackageSmoke](Span(encode(sent)))
+    assert_equal(received.request_id, 42)
+    assert_equal(received.payload, "installed package")
+    assert_equal(received.state.value, SmokeState.SMOKE_STATE_READY)
+    assert_equal(
+        decode[PackagePayload](Span(received.metadata.value().value)).note,
+        "resolved from installed codegen",
+    )
+
+    var print_options = JsonPrintOptions(
+        type_resolver=json_type_resolver()
+    )
+    var parse_options = JsonParseOptions(
+        type_resolver=json_type_resolver()
+    )
+    var text = encode_json(sent, options=print_options)
+    var json_received = decode_json[PackageSmoke](
+        text, options=parse_options
+    )
+    assert_equal(json_received.request_id, 42)
+    assert_equal(json_received.payload, "installed package")
+    assert_equal(json_received.state.value, SmokeState.SMOKE_STATE_READY)
+    assert_equal(
+        decode[PackagePayload](
+            Span(json_received.metadata.value().value)
+        ).note,
+        "resolved from installed codegen",
+    )
+    print("protomojo package smoke test passed")

--- a/recipes/protomojo/tests/package_smoke.proto
+++ b/recipes/protomojo/tests/package_smoke.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+
+enum SmokeState {
+  SMOKE_STATE_UNSPECIFIED = 0;
+  SMOKE_STATE_READY = 1;
+}
+
+message PackageSmoke {
+  uint32 request_id = 1;
+  string payload = 2;
+  SmokeState state = 3;
+  google.protobuf.Any metadata = 4;
+}
+
+message PackagePayload {
+  string note = 1;
+}

--- a/scripts/build-all.py
+++ b/scripts/build-all.py
@@ -1,6 +1,13 @@
-from pathlib import Path
+from collections import defaultdict, deque
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 import argparse
+import os
+import sys
+
+import yaml
+
 from scripts.common import (
     load_failed_compatibility,
     recipe_name_collisions,
@@ -8,13 +15,150 @@ from scripts.common import (
     save_failed_compatibility,
     eprint,
 )
-import sys
-import os
 
 # Channels are in priority order
 MODULAR_COMMUNITY_CHANNEL = "https://prefix.dev/modular-community"
 MAX_CHANNEL = "https://conda.modular.com/max"
 DEFAULT_CHANNELS = ["conda-forge", MAX_CHANNEL, MODULAR_COMMUNITY_CHANNEL]
+LOCAL_OUTPUT = Path("output")
+
+
+def _spec_name(spec: str) -> str:
+    token = spec.strip().split()[0] if spec.strip() else ""
+    if not token or token.startswith("${{"):
+        return ""
+    return token
+
+
+def _requirement_names(node: Any) -> list[str]:
+    names: list[str] = []
+    if node is None:
+        return names
+    if isinstance(node, str):
+        name = _spec_name(node)
+        if name:
+            names.append(name)
+        return names
+    if isinstance(node, list):
+        for item in node:
+            names.extend(_requirement_names(item))
+        return names
+    if isinstance(node, dict):
+        for key in ("then", "else"):
+            if key in node:
+                names.extend(_requirement_names(node[key]))
+        return names
+    return names
+
+
+def _package_name(recipe_file: Path) -> str | None:
+    with recipe_file.open() as fh:
+        recipe_data = yaml.safe_load(fh) or {}
+    name = recipe_data.get("package", {}).get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return name.strip()
+
+
+def _sibling_dependencies(recipe_file: Path, known_packages: set[str]) -> set[str]:
+    with recipe_file.open() as fh:
+        recipe_data = yaml.safe_load(fh) or {}
+    reqs = recipe_data.get("requirements") or {}
+    names: set[str] = set()
+    for section in ("host", "run", "build"):
+        names.update(_requirement_names(reqs.get(section)))
+    self_name = recipe_data.get("package", {}).get("name")
+    if isinstance(self_name, str):
+        names.discard(self_name.strip())
+    return names & known_packages
+
+
+def order_recipes(recipe_dirs: list[Path]) -> list[Path]:
+    """Build sibling packages before the recipes that depend on them."""
+    package_to_dir: dict[str, Path] = {}
+    for recipe_dir in recipe_dirs:
+        name = _package_name(recipe_dir / "recipe.yaml")
+        if name is None:
+            eprint(f"Invalid package name in {recipe_dir / 'recipe.yaml'}")
+            continue
+        package_to_dir[name] = recipe_dir
+
+    known = set(package_to_dir)
+    dependents: dict[str, set[str]] = defaultdict(set)
+    indegree: dict[str, int] = {name: 0 for name in known}
+    for name, recipe_dir in package_to_dir.items():
+        deps = _sibling_dependencies(recipe_dir / "recipe.yaml", known)
+        indegree[name] = len(deps)
+        for dep in deps:
+            dependents[dep].add(name)
+
+    ready = deque(sorted(name for name, degree in indegree.items() if degree == 0))
+    ordered: list[str] = []
+    while ready:
+        name = ready.popleft()
+        ordered.append(name)
+        for dependent in sorted(dependents[name]):
+            indegree[dependent] -= 1
+            if indegree[dependent] == 0:
+                ready.append(dependent)
+
+    if len(ordered) != len(known):
+        leftover = sorted(known - set(ordered))
+        eprint(
+            "Recipe dependency cycle or unresolved sibling deps; "
+            f"appending in name order: {', '.join(leftover)}"
+        )
+        ordered.extend(leftover)
+
+    return [package_to_dir[name] for name in ordered]
+
+
+def _build_command(
+    recipe_file: Path,
+    extra_channels: list[str] | None,
+    variant_config: str,
+) -> list[str]:
+    command = ["rattler-build", "build"]
+    if LOCAL_OUTPUT.is_dir():
+        command.extend(["--channel", str(LOCAL_OUTPUT.resolve())])
+    for channel in DEFAULT_CHANNELS:
+        command.extend(["--channel", channel])
+    if extra_channels is not None:
+        for channel in extra_channels:
+            if channel in DEFAULT_CHANNELS:
+                continue
+            command.extend(["--channel", channel])
+    command.extend(
+        [
+            "--variant-config",
+            variant_config,
+            "--skip-existing=all",
+            "--recipe",
+            str(recipe_file),
+        ]
+    )
+    return command
+
+
+def _record_success(
+    recipe_dir: Path, failed_compatibility: dict[str, dict[str, str]] | None
+) -> None:
+    print(f"Successfully built recipe {recipe_dir.name}")
+    if failed_compatibility is not None and recipe_dir.name in failed_compatibility:
+        del failed_compatibility[recipe_dir.name]
+        print(f"Removed {recipe_dir.name} from failed-compatibility.json")
+
+
+def _record_failure(
+    recipe_dir: Path,
+    stderr: str,
+    failed_compatibility: dict[str, dict[str, str]] | None,
+) -> None:
+    eprint(f"Error building recipe in {recipe_dir}: {stderr}")
+    if failed_compatibility is not None:
+        failed_compatibility[recipe_dir.name] = {
+            "failed_at": datetime.now().isoformat()
+        }
 
 
 def main() -> None:
@@ -45,57 +189,47 @@ def main() -> None:
         c for c in DEFAULT_CHANNELS if c != MODULAR_COMMUNITY_CHANNEL
     ]
 
-    for recipe_dir in base_dir.iterdir():
+    recipe_dirs: list[Path] = []
+    for recipe_dir in sorted(base_dir.iterdir(), key=lambda path: path.name.lower()):
         recipe_file = recipe_dir / "recipe.yaml"
         if not recipe_file.is_file():
             eprint(f"{recipe_dir} doesn't contain recipe.yaml")
             continue
+        recipe_dirs.append(recipe_dir)
 
-        if recipe_name_collisions(
-            recipe_file, channels=default_channels_without_community
-        ):
-            eprint(
-                f"SKIPPING: {recipe_file} specifies a recipe whose name collides with another conda package in {default_channels_without_community}."
-            )
-            continue
+    pending = order_recipes(recipe_dirs)
+    for build_pass in (1, 2):
+        still_pending: list[Path] = []
+        for recipe_dir in pending:
+            recipe_file = recipe_dir / "recipe.yaml"
+            if recipe_name_collisions(
+                recipe_file, channels=default_channels_without_community
+            ):
+                eprint(
+                    f"SKIPPING: {recipe_file} specifies a recipe whose name collides with another conda package in {default_channels_without_community}."
+                )
+                continue
 
-        command = [
-            "rattler-build",
-            "build",
-        ]
+            command = _build_command(recipe_file, args.channel, variant_config)
+            result = run_command_unchecked(command)
+            if result.returncode != 0:
+                still_pending.append(recipe_dir)
+                if build_pass == 2:
+                    _record_failure(
+                        recipe_dir, result.stderr, failed_compatibility
+                    )
+                    exit_code = 1
+                else:
+                    eprint(
+                        f"First pass failed for {recipe_dir.name}; "
+                        "retrying after remaining recipes"
+                    )
+            else:
+                _record_success(recipe_dir, failed_compatibility)
 
-        for channel in DEFAULT_CHANNELS:
-            command.extend(["--channel", channel])
-
-        if args.channel is not None:
-            for channel in args.channel:
-                if channel in DEFAULT_CHANNELS:
-                    continue
-                command.extend(["--channel", channel])
-
-        command.extend(
-            [
-                "--variant-config",
-                variant_config,
-                "--skip-existing=all",
-                "--recipe",
-                str(recipe_file),
-            ]
-        )
-        result = run_command_unchecked(command)
-        if result.returncode != 0:
-            eprint(f"Error building recipe in {recipe_dir}: {result.stderr}")
-            exit_code = 1
-            if failed_compatibility is not None:
-                failed_compatibility[recipe_dir.name] = {
-                    "failed_at": datetime.now().isoformat()
-                }
-        else:
-            print(f"Successfully built recipe {recipe_dir.name}")
-            if failed_compatibility is not None:
-                if recipe_dir.name in failed_compatibility:
-                    del failed_compatibility[recipe_dir.name]
-                    print(f"Removed {recipe_dir.name} from failed-compatibility.json")
+        pending = still_pending
+        if not pending:
+            break
 
     if failed_compatibility is not None:
         # Save updated failed compatibility data


### PR DESCRIPTION
Adds five Mojo 1.0 packages:

| Package | Version | Source |
| --- | --- | --- |
| mojo-net | 0.2.4 | https://github.com/nsalerni/mojo-net.git @ `2bb696e053c691df8e59f9ffd77a92603e374395` |
| protomojo | 0.4.0 | https://github.com/nsalerni/protomojo.git @ `734f2812d06f0205075861e9e9f709aa94198848` |
| mojo-tls | 0.3.0 | https://github.com/nsalerni/mojo-tls.git @ `5c578bd556c64810aec5fa60652780e25570ab4c` |
| mojo-http2 | 0.2.7 | https://github.com/nsalerni/mojo-http2.git @ `4aed60e49715a0b3bf9776daa99f3038411babea` |
| grpc-mojo | 0.2.2 | https://github.com/nsalerni/grpc-mojo.git @ `2aee07fdd64a82745f368414f244f4efb664730c` |

**grpc-mojo source.** The GitHub tag `v0.2.2` still pins `mojo-tls >=0.2.0,<0.3.0` (and `protomojo` 0.2.x). Current main already requires mojo-tls 0.3, protomojo 0.4, and mojo-http2 0.2.x, and the package tests import tls 0.3 types. This recipe therefore pins current main, not the older tag. A follow-up grpc-mojo GitHub release would make the tag and the conda package match.

**Build order.** `scripts/build-all.py` now:

- feeds rattler-build's local `output/` directory back as a channel so packages built earlier in the same run can satisfy siblings
- topologically sorts recipes by sibling host/run/build dependencies (net → tls → http2 → grpc; protomojo has no sibling deps)
- retries remaining failures once

mojo-http2 no longer has to wait for a second channel `build-all` after an alphabetical first pass.

Sources use `mojo precompile` and ship `.mojoc` (not `.mojopkg`). `license_file` is `LICENSE`. Build number is `0`. mojo-tls also builds a C OpenSSL shim.

**Checklist**
- [x] `mojo-compiler >=1.0.0,<1.1.0`
- [x] License file is packaged (`license_file: LICENSE`)
- [x] Build number set to `0` (new packages)
- [x] N/A: bump build number (versions are new)

Please add the **OK to test** label. PR CI in `.github/workflows/build-pr.yml` only runs when that label is present.
