### PR TITLE
Add mojo-window package

### DIFF
--- a/recipes/mojo-window/recipe.yaml
+++ b/recipes/mojo-window/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: mojo-window
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/Maelkiz/mojo-window.git
+    rev: v0.1.0
+
+build:
+  number: 0
+  script:
+    - mojo precompile src/window -o ${{ PREFIX }}/lib/mojo/window.mojoc
+
+requirements:
+  build:
+    - mojo-compiler =1.0.0
+  host:
+    - mojo-compiler =1.0.0
+    - sdl3 >=3.4,<4
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+    - sdl3 >=3.4,<4
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run test.mojo
+    files:
+      recipe:
+        - test.mojo
+
+about:
+  homepage: https://github.com/Maelkiz/mojo-window
+  repository: https://github.com/Maelkiz/mojo-window
+  license: MIT
+  license_file: LICENSE
+  summary: SDL3-based windowing library for Mojo
+
+extra:
+  maintainers:
+    - Maelkiz

--- a/recipes/mojo-window/recipe.yaml
+++ b/recipes/mojo-window/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.0"
+  version: "0.1.1"
 
 package:
   name: mojo-window
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/Maelkiz/mojo-window.git
-    rev: v0.1.0
+    rev: v0.1.1
 
 build:
   number: 0

--- a/recipes/mojo-window/test.mojo
+++ b/recipes/mojo-window/test.mojo
@@ -1,0 +1,59 @@
+"""Smoke tests for the mojo-window package. Runs headless via SDL dummy driver."""
+
+from std.os import setenv
+from std.testing import TestSuite, assert_true, assert_false, assert_equal, assert_raises
+from window import (
+    Window,
+    GLWindow,
+    Event,
+    Quit,
+    Resized,
+    KeyDown,
+    KeyUp,
+    MouseMoved,
+    MouseButtonDown,
+    MouseButtonUp,
+    MouseWheel,
+)
+
+
+def test_window_open_and_close() raises -> None:
+    var w = Window("t", 100, 100)
+    assert_true(w.is_open())
+    w.close()
+    assert_false(w.is_open())
+
+
+def test_window_poll_returns_no_events() raises -> None:
+    var w = Window("t", 64, 64)
+    var events = w.events()
+    assert_true(len(events) == 0)
+
+
+def test_gl_window_fails_cleanly_under_dummy_driver() raises -> None:
+    with assert_raises(contains="SDL_CreateWindow failed"):
+        var w = GLWindow("t", 64, 64)
+
+
+def test_event_variants() raises -> None:
+    assert_true((Event(Quit())).isa[Quit]())
+    var r: Event = Resized(800, 600)
+    assert_equal(r[Resized].width, 800)
+    assert_equal(r[Resized].height, 600)
+    var kd: Event = KeyDown(42)
+    assert_equal(kd[KeyDown].keycode, 42)
+    var ku: Event = KeyUp(7)
+    assert_equal(ku[KeyUp].keycode, 7)
+    var mm: Event = MouseMoved(12, 34)
+    assert_equal(mm[MouseMoved].x, 12)
+    var mbd: Event = MouseButtonDown(1, 5, 6)
+    assert_equal(mbd[MouseButtonDown].button, 1)
+    var mbu: Event = MouseButtonUp(2, 9, 10)
+    assert_equal(mbu[MouseButtonUp].button, 2)
+    var mw: Event = MouseWheel(0, -1)
+    assert_equal(mw[MouseWheel].y, -1)
+
+
+def main() raises:
+    _ = setenv("SDL_VIDEODRIVER", "dummy", True)
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Adds the mojo-window package - an SDL3-based windowing library I made as I needed it for another project.

Source code: https://github.com/Maelkiz/mojo-window

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
