### PR TITLE
Add heat-url 1.0.0

### DIFF
--- a/recipes/heat-url/recipe.yaml
+++ b/recipes/heat-url/recipe.yaml
@@ -1,5 +1,3 @@
-# Local builds use the checkout (`path`). For modular-community, replace
-# `source` with the git URL and a full 40-character commit SHA.
 context:
   version: "1.0.0"
 

--- a/recipes/heat-url/recipe.yaml
+++ b/recipes/heat-url/recipe.yaml
@@ -1,0 +1,51 @@
+# Local builds use the checkout (`path`). For modular-community, replace
+# `source` with the git URL and a full 40-character commit SHA.
+context:
+  version: "1.0.0"
+
+package:
+  name: heat-url
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/joeressler/heat-url.git
+    rev: fb44a8b0ccfc611a46935cc9d9e6f1cda1f4a05b
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${{ PREFIX }}/lib/mojo
+    - mojo precompile src/heat_url -o ${{ PREFIX }}/lib/mojo/heat_url.mojoc
+
+requirements:
+  host:
+    - mojo-compiler =1.0.0
+  build:
+    - mojo-compiler =1.0.0
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run test_heat_url.mojo
+    files:
+      recipe:
+        - test_heat_url.mojo
+    requirements:
+      run:
+        - mojo =1.0.0
+
+about:
+  homepage: https://github.com/joeressler/heat-url
+  repository: https://github.com/joeressler/heat-url
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: URI and URL parsing for Mojo (WHATWG and RFC 3986), with native IDNA.
+
+extra:
+  maintainers:
+    - joeressler
+  project_name:
+    - heat-url

--- a/recipes/heat-url/test_heat_url.mojo
+++ b/recipes/heat-url/test_heat_url.mojo
@@ -1,0 +1,12 @@
+from heat_url import VERSION, parse_uri, parse_url, try_parse_url
+from std.testing import assert_equal, assert_true
+
+
+def main() raises:
+    assert_equal(String(VERSION), "1.0.0")
+    var url = parse_url("https:example.org")
+    assert_equal(url.serialize(), "https://example.org/")
+    var uri = parse_uri("https:example.org")
+    assert_equal(uri.serialize(), "https:example.org")
+    assert_true(try_parse_url("https://ex ample.org/") is None)
+    print("heat-url package ok")


### PR DESCRIPTION
[Heat-url](https://github.com/joeressler/heat-url) is a small URL/URI parsing utility

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
