### PR TITLE
Update strata recipe

### DIFF
--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: 95a838bb78f799774aafb2c8a6aa503f5fcbf4d9
+    rev: 3c9775e59126d63202398ff5033614eed50b294f
 
 build:
   number: 0

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -1,0 +1,49 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: strata
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/ethqnol/Strata.git
+    rev: 95a838bb78f799774aafb2c8a6aa503f5fcbf4d9
+
+build:
+  number: 0
+  script:
+    - mojo precompile strata -o ${{ PREFIX }}/lib/mojo/strata.mojoc
+
+requirements:
+  build:
+    - mojo-compiler >=1.0.0
+  host:
+    - mojo-compiler >=1.0.0
+    - liblapack
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+    - liblapack
+    - python >=3.10
+    - numpy
+    - scipy
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run scripts/run_tests.mojo
+    files:
+      source:
+        - scripts/
+        - tests/
+
+about:
+  homepage: https://github.com/ethqnol/Strata
+  repository: https://github.com/ethqnol/Strata
+  license: MIT
+  license_file: LICENSE
+  summary: Strata is a high-performance machine learning library written in native Mojo. It provides scikit-learn compatible estimator APIs while taking advantage of Mojo's compile-time optimizations and SIMD acceleration.
+
+extra:
+  maintainers:
+    - ethqnol # Ethan Wu 

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script:
-    - mojo package strata -o ${{ PREFIX }}/lib/mojo/strata.mojoc
+    - mojo package strata -o ${{ PREFIX }}/lib/mojo/strata.mojopkg
 
 requirements:
   build:

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: ac9b0d12af65369d3d133b0a684c277122bb6cee
+    rev: 4b1c043462517252dce552c6965c8c63d15a50c6
 
 build:
   number: 0
@@ -22,9 +22,11 @@ requirements:
   host:
     - mojo-compiler ${{ mojo_version }}
     - liblapack
+    - libblas
   run:
     - mojo-compiler ${{ mojo_version }}
     - liblapack
+    - libblas
     - python >=3.10
     - numpy
     - scipy

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script:
-    - mojo precompile strata -o ${{ PREFIX }}/lib/mojo/strata.mojoc
+    - mojo package strata -o ${{ PREFIX }}/lib/mojo/strata.mojoc
 
 requirements:
   build:

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.0"
+  version: "0.1.1"
   mojo_version: "=1.0.0"
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: 4b1c043462517252dce552c6965c8c63d15a50c6
+    rev: 59ee76d1860843ef3fc6356ed316b70f4ce0b08c
 
 build:
   number: 0

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: 8b1ede199d750c18d361da5264b38bf3b05f24f8
+    rev: ac9b0d12af65369d3d133b0a684c277122bb6cee
 
 build:
   number: 0

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: 3c9775e59126d63202398ff5033614eed50b294f
+    rev: 8b1ede199d750c18d361da5264b38bf3b05f24f8
 
 build:
   number: 0
@@ -46,4 +46,4 @@ about:
 
 extra:
   maintainers:
-    - ethqnol # Ethan Wu 
+    - ethqnol # Ethan Wu

--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -1,5 +1,6 @@
 context:
   version: "0.1.0"
+  mojo_version: "=1.0.0"
 
 package:
   name: strata
@@ -12,16 +13,17 @@ source:
 build:
   number: 0
   script:
-    - mojo package strata -o ${{ PREFIX }}/lib/mojo/strata.mojopkg
+    - mkdir -p "${PREFIX}/lib/mojo"
+    - mojo precompile strata -o "${PREFIX}/lib/mojo/strata.mojoc"
 
 requirements:
   build:
-    - mojo-compiler >=1.0.0
+    - mojo-compiler ${{ mojo_version }}
   host:
-    - mojo-compiler >=1.0.0
+    - mojo-compiler ${{ mojo_version }}
     - liblapack
   run:
-    - ${{ pin_compatible('mojo-compiler') }}
+    - mojo-compiler ${{ mojo_version }}
     - liblapack
     - python >=3.10
     - numpy
@@ -32,6 +34,9 @@ tests:
       - if: unix
         then:
           - mojo run scripts/run_tests.mojo
+    requirements:
+      run:
+        - mojo ${{ mojo_version }}
     files:
       source:
         - scripts/


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
