### PR TITLE
Update Strata to v0.1.1

### DIFF
--- a/recipes/strata/recipe.yaml
+++ b/recipes/strata/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.0"
+  version: "0.1.1"
   mojo_version: "=1.0.0"
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - git: https://github.com/ethqnol/Strata.git
-    rev: ac9b0d12af65369d3d133b0a684c277122bb6cee
+    rev: 59ee76d1860843ef3fc6356ed316b70f4ce0b08c
 
 build:
   number: 0
@@ -22,9 +22,11 @@ requirements:
   host:
     - mojo-compiler ${{ mojo_version }}
     - liblapack
+    - libblas
   run:
     - mojo-compiler ${{ mojo_version }}
     - liblapack
+    - libblas
     - python >=3.10
     - numpy
     - scipy


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
