### PR TITLE
Update safetensors-mojo to 0.7.0

### DIFF
--- a/recipes/safetensors-mojo/recipe.yaml
+++ b/recipes/safetensors-mojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.6.0"
+  version: "0.7.0"
 
 package:
   name: safetensors-mojo
@@ -7,13 +7,10 @@ package:
 
 source:
   - git: https://github.com/egor-fedorov/safetensors.mojo.git
-    rev: 5283910124f09d3ba51a53b85a2ff34cb4e738a2
+    rev: 560a28664baa395f4dd6e493f3370c3ce9838d3e
 
 build:
   number: 0
-  skip:
-    - osx
-    - linux and aarch64
   script:
     - mkdir -p "${PREFIX}/lib/mojo"
     - mojo precompile src/safetensors -o "${PREFIX}/lib/mojo/safetensors.mojoc"

--- a/recipes/safetensors-mojo/recipe.yaml
+++ b/recipes/safetensors-mojo/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.5.0"
+  version: "0.6.0"
 
 package:
   name: safetensors-mojo
@@ -7,7 +7,7 @@ package:
 
 source:
   - git: https://github.com/egor-fedorov/safetensors.mojo.git
-    rev: 1dd3450d02a39b4b8b5cfee01e82c88743bec72b
+    rev: 5283910124f09d3ba51a53b85a2ff34cb4e738a2
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Update `safetensors-mojo` from 0.5.0 to 0.7.0.

- Pin the recipe to the immutable commit behind the annotated `v0.7.0` tag.
- Build and test on every native platform supported by Mojo 1.0.0: `linux-64`, `linux-aarch64`, and `osx-arm64`.
- Include local sharded Safetensors index support introduced in 0.6.0.
- Include the portable mapped I/O, atomic writing, and secure sharded path resolution work completed in 0.7.0.

## Validation

- `pixi run lint`
- Direct recipe schema validation
- Render and solve for `linux-64`, `linux-aarch64`, and `osx-arm64`
- Native `linux-64` package build and installed-package smoke test
- [Source CI](https://github.com/egor-fedorov/safetensors.mojo/actions/runs/33690648748)
- [Release workflow](https://github.com/egor-fedorov/safetensors.mojo/actions/runs/33691058953)

## Checklist

- [x] Recipe source is pinned to a full commit SHA.
- [x] Build number remains `0` for the new upstream version.
- [x] Package license metadata remains unchanged.
- [x] MAX compatibility is not applicable; this is a standalone Mojo package.
