### PR TITLE
Bump mojo-raylib to 0.2.1

### DIFF
--- a/recipes/mojo_raylib/recipe.yaml
+++ b/recipes/mojo_raylib/recipe.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
-  version: "0.2.0"
+  version: "0.2.1"
   mojo_version: "=1.0.0"
-  rev: "f11c881463caaccf94ec16f4d9c01f50adfcf280"
+  rev: "b2fde00e920b8b61e138b7961e090c86dd2ed92f"
 
 package:
   name: "mojo_raylib"
@@ -28,6 +28,7 @@ requirements:
     - ${{ compiler('c') }}
     - cmake
     - ninja
+    - patchelf
   host:
     - mojo-compiler ${{ mojo_version }}
     - if: linux


### PR DESCRIPTION
**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ ] Set the build number to `0` (for new packages, or if the version changed).
- [ ] Bumped the build number (if the version is unchanged).
