### PR TITLE
Add wgpu-mojo

### DIFF
--- a/recipes/wgpu-mojo/recipe.yaml
+++ b/recipes/wgpu-mojo/recipe.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+#
+# This is the recipe submitted to the modular-community channel, and the one
+# release.yml builds for GitHub Releases. Keep it submission-shaped: source
+# pinned to a full commit SHA, tests that run in a bare environment, and no
+# network access from the build script.
+#
+# Validate it against the working tree (no pushed SHA needed) with:
+#     pixi run check-recipe
+context:
+  version: "0.2.1"
+
+  # modular-community requires a full 40-character commit SHA -- never a branch
+  # or a tag, both of which can be repointed after review. A commit cannot
+  # contain its own hash, so this is set in the commit *after* the version bump
+  # and before the tag; release.yml then refuses to build unless the source at
+  # this revision matches the tagged source outside conda.recipe/. See
+  # CONTRIBUTING.md, "Releasing".
+  rev: "2dc4f7f6dece61a2aafa60b3dd22b48b13a335d9"
+
+  # Exact, not a range. wgpu-native renumbered the whole 0x0003xxxx SType enum
+  # in the v29.0.0.0 -> v29.0.1.1 *patch* release, so a "compatible" newer patch
+  # silently misreads every extras chain. conda.recipe/build.sh additionally
+  # compares the installed header against the copy vendored in this repo.
+  wgpu_native_version: "29.0.0.0"
+
+  # Pinned exactly, per the modular-community packaging guide: a package is
+  # rebuilt (build.number += 1) against each new compiler release rather than
+  # claiming forward compatibility it has not been tested for.
+  mojo_version: "=1.0.0"
+
+package:
+  name: wgpu-mojo
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/Hundo1018/wgpu-mojo.git
+    rev: ${{ rev }}
+
+build:
+  number: 0
+  # linux-64 and osx-arm64 are the platforms this project declares, tests in CI
+  # and can verify. modular-community also builds linux-aarch64; nothing here is
+  # x86-specific and conda-forge ships wgpu-native for it, but shipping a package
+  # nobody has run is exactly the kind of unverified claim this repo avoids.
+  skip:
+    - target_platform != "linux-64" and target_platform != "osx-arm64"
+  script:
+    interpreter: bash
+    content:
+      - bash conda.recipe/build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    # Both are real link-time and run-time dependencies of the C bridges built
+    # by conda.recipe/build.sh, and both are what make `pixi add wgpu-mojo`
+    # sufficient on its own -- the previous revision downloaded wgpu-native
+    # from GitHub Releases at build time and left glfw to the user entirely.
+    - wgpu-native ==${{ wgpu_native_version }}
+    - glfw >=3.4,<4
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+    - wgpu-native ==${{ wgpu_native_version }}
+    - glfw >=3.4,<4
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - mojo run test_package.mojo
+    files:
+      recipe:
+        - test_package.mojo
+    requirements:
+      run:
+        - mojo ${{ mojo_version }}
+
+about:
+  homepage: https://github.com/Hundo1018/wgpu-mojo
+  repository: https://github.com/Hundo1018/wgpu-mojo
+  documentation: https://github.com/Hundo1018/wgpu-mojo#readme
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: WebGPU for Mojo — pure bindings to wgpu-native, with RAII GPU objects
+  description: |
+    Pure Mojo bindings for wgpu-native (WebGPU): compute and graphics on every
+    backend Vulkan / Metal / DX12 supports, from a single Mojo program.
+
+    Every GPU object is an RAII wrapper that releases its native handle on
+    scope exit, handles are strongly-typed newtypes rather than raw pointers,
+    and a high-level GPU facade does compile + dispatch + read-back in a few
+    lines. Includes a GLFW-backed RenderCanvas for windowed rendering.
+
+extra:
+  maintainers:
+    - Hundo1018
+  project_name: wgpu-mojo

--- a/recipes/wgpu-mojo/test_package.mojo
+++ b/recipes/wgpu-mojo/test_package.mojo
@@ -1,0 +1,29 @@
+# Package test for the wgpu-mojo conda package.
+#
+# rattler-build runs this in a fresh environment containing only the package
+# and its declared runtime dependencies -- no repo checkout, no -I flag, no
+# LD_LIBRARY_PATH from a dev tree. So it fails if any of these is untrue:
+#
+#   1. lib/mojo/wgpu.mojoc is where the Mojo compiler looks for it
+#      (otherwise `from wgpu import ...` does not resolve)
+#   2. libwgpu_native and libwgpu_mojo_cb are both installed and loadable
+#      (check_symbols() constructs a WGPULib, which dlopens both)
+#   3. the installed wgpu-native exports the ABI this binding targets
+#      (check_symbols() probes the drift-prone entry points by name)
+#
+# Deliberately no adapter request: this must pass on a build machine with no
+# GPU and no display server.
+from wgpu import Instance
+from wgpu.diagnostics import check_symbols
+
+
+def main() raises:
+    var missing = check_symbols()
+    if len(missing) != 0:
+        var msg = String(
+            "installed wgpu-native is missing "
+        ) + String(len(missing)) + " critical symbols:"
+        for name in missing:
+            msg += "\n  " + name
+        raise Error(msg)
+    print("wgpu-mojo package test OK — package resolves, native libs load, ABI matches")


### PR DESCRIPTION
Add `wgpu-mojo` — pure Mojo bindings for [wgpu-native](https://github.com/gfx-rs/wgpu-native) (WebGPU).

Compute and graphics on every backend Vulkan / Metal / DX12 supports, from a single
Mojo program: RAII wrappers that release their native handle on scope exit,
strongly-typed handle newtypes instead of raw pointers, a high-level `GPU` facade
that does compile + dispatch + read-back in a few lines, and a GLFW-backed
`RenderCanvas` for windowed rendering.

- Source: https://github.com/Hundo1018/wgpu-mojo
- Release: https://github.com/Hundo1018/wgpu-mojo/releases/tag/v0.2.1
- License: Apache-2.0
- Maintainer: @Hundo1018

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project. — This package does not depend on `max` at all. It pins `mojo-compiler =1.0.0` in build/host and uses `pin_compatible('mojo-compiler')` at run time, per the packaging guide. The MAX interop bridge lives in a separate top-level package that is deliberately excluded from the build, precisely so `max` stays off every consumer's dependency path.
- [x] License file is packaged. — `license_file: LICENSE`; verified present as `info/licenses/LICENSE` in the built artifact.
- [x] Set the build number to `0`. — New package.
- [x] Bumped the build number (if the version is unchanged). — N/A, first submission.

## Notes for reviewers

**Platforms.** The recipe skips everything except `linux-64` and `osx-arm64`,
including the `linux-aarch64` this repo's CI builds. Nothing in the binding is
architecture-specific and conda-forge ships `wgpu-native` for aarch64, but no one
has run wgpu-mojo there, so I would rather not publish a package nobody has
exercised. I checked that the skip expression resolves correctly on all five
targets, so the aarch64 leg exits cleanly rather than failing your build.

**Native dependency.** `wgpu-native` and `glfw` are declared host/run
dependencies resolved from conda-forge — the build script downloads nothing. It
compiles the two C callback bridges from source in the repo (wgpu-native's async
API needs real C function pointers, which Mojo cannot yet produce) and links
against the host environment.

**ABI pin.** `wgpu-native` is pinned exactly, not as a range. Upstream renumbered
the whole `0x0003xxxx` SType enum in the v29.0.0.0 → v29.0.1.1 *patch* release; a
mismatched library still loads and still runs, it just misreads every extras
chain. Beyond the version constraint, `conda.recipe/build.sh` compares the
installed `$PREFIX/include/wgpu.h` byte-for-byte against the copy vendored in the
source repo and fails the build on any difference.

**CodeQL** is enabled on the source repository (it contains C and Python
alongside Mojo) and the badge is in the README.

**Test.** `test_package.mojo` runs in a bare environment and asserts three things:
that `lib/mojo/wgpu.mojoc` is discoverable without an `-I` flag, that both native
libraries load, and that the installed wgpu-native exports the drift-prone entry
points this binding targets. It requests no adapter, so it passes on a build
machine with no GPU and no display server.

## Verification performed

Built from this exact recipe and revision, then installed from a local channel
into a throwaway pixi project with no source checkout on the path, no `-I` flag
and no inherited `LD_LIBRARY_PATH`:

```
==> pixi add wgpu-mojo
✔ Added wgpu-mojo >=0.2.1,<0.3

==> Assertion 1: package resolves, native libraries load
wgpu preflight OK
  wgpu-native version: 486539264
  symbol check: OK (25 critical symbols present)
  adapters found: 4

==> Assertion 2: compute round trip on a real adapter
compute round trip OK — all 1024 elements correct
```

The same was repeated against the published `.conda` downloaded back from the
GitHub Release, and the package test passes standalone via
`rattler-build test --package-file`. Both checks run in the source repo's CI on
`ubuntu-latest` and `macos-14`.
