### PR TITLE
mojo_csv update for 1.0 public

### DIFF
--- a/recipes/mojo_csv/recipe.yaml
+++ b/recipes/mojo_csv/recipe.yaml
@@ -1,12 +1,12 @@
 context:
-  version: 1.6.3
+  version: 1.6.4
 package:
   name: "mojo_csv"
   version: ${{ version }}
 
 source:
   - git: https://github.com/Phelsong/mojo_csv.git
-    rev: eb72d0b61a62b8e51754ab0b235bf12e7092cd57
+    rev: 9acfd0d71d772e9f1dee445262772a39cf9b0e66
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
 
 requirements:
   host:
-    - max >=26.0,<27.0
+    - max >=26.3.0,<27.0
   run:
     - ${{ pin_compatible('max') }}
 
@@ -23,13 +23,13 @@ tests:
   - script:
       - if: unix
         then:
-          - mojo run -I $PREFIX/lib/mojo/mojo_csv.mojopkg test_pack.mojo
+          - mojo run -I $PREFIX/lib/mojo/mojo_csv.mojoc test_pack.mojo
     files:
       recipe:
         - test_pack.mojo
     requirements:
       run:
-        - max >=26.0,<27.0
+        - max >=26.3.0,<27.0
 
 about:
   homepage: https://github.com/Phelsong/mojo_csv


### PR DESCRIPTION
**Checklist**
- [ x ] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [ x ] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [ x ] Set the build number to `0` (for new packages, or if the version changed).
- [ x ] Bumped the build number (if the version is unchanged).


just syntax and dependency updates for 1.0.