### PR TITLE
fix: commit-changes.py modified to check if there are changes (#347)

### DIFF
--- a/scripts/commit-changes.py
+++ b/scripts/commit-changes.py
@@ -2,7 +2,12 @@ import sys
 from pathlib import Path
 import argparse
 
-from scripts.common import commit_push_changes, eprint, run_command
+from scripts.common import (
+    commit_push_changes,
+    eprint,
+    run_command,
+    run_command_unchecked,
+)
 
 
 def main() -> None:
@@ -14,8 +19,15 @@ def main() -> None:
         eprint(f"{args.file} does not exist.")
         sys.exit(1)
 
-    # Commit and push changes
     run_command(["git", "add", str(args.file)])
+
+    # Check if there are changes to commit
+    result = run_command_unchecked(["git", "diff-index", "--cached", "--quiet", "HEAD"])
+    if result.returncode == 0:
+        print("No changes to commit")
+        sys.exit(0)
+
+    # Commit and push changes
     commit_push_changes(f"Update {args.file.name}", "main")
 
 


### PR DESCRIPTION

Fixes #347

### Problem
In CI where there are no changes, `pixi run commit-changes` runs `git commit`, which failed because the there was nothing to commit, which causes the workflow to fail.

### Fix
- Check for staged changes in `scripts/commit-changes.py` using `git diff-index --cached --quiet HEAD` after running `git add`.
- If no changes are detected, print `"No changes to commit"` and exit with `0`.
