### PR TITLE
Add mojo-tls 0.3.2

### DIFF
--- a/recipes/mojo-tls/recipe.yaml
+++ b/recipes/mojo-tls/recipe.yaml
@@ -1,0 +1,170 @@
+context:
+  version: "0.3.2"
+  mojo_version: ">=1.0.0,<1.1.0"
+  mojo_net_version: ">=0.2.5,<0.3.0"
+  openssl_version: ">=3.0,<4.0a0"
+
+package:
+  name: mojo-tls
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/mojo-tls.git
+    rev: f79b8ae0013b9f1011694c8d93a0317fc22ebe28
+
+build:
+  number: 0
+  dynamic_linking:
+    # The shim sets platform-native relative loader paths below.
+    binary_relocation: false
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        : "${CC:?the package build must provide a C compiler}"
+        mkdir -p "${PREFIX}/lib" "${PREFIX}/lib/mojo"
+
+        case "$(uname -s)" in
+          Darwin)
+            "${CC}" -dynamiclib -fPIC -O2 -Wall -Werror \
+              -I"${PREFIX}/include" \
+              -L"${PREFIX}/lib" \
+              -Wl,-rpath,@loader_path \
+              -Wl,-install_name,@rpath/libmojotls.dylib \
+              -o "${PREFIX}/lib/libmojotls.dylib" \
+              shim/mojotls_shim.c -lssl -lcrypto
+            ;;
+          *)
+            "${CC}" -shared -fPIC -O2 -Wall -Werror -pthread \
+              -I"${PREFIX}/include" \
+              -L"${PREFIX}/lib" \
+              -Wl,-rpath,'$ORIGIN' \
+              -Wl,-soname,libmojotls.so \
+              -o "${PREFIX}/lib/libmojotls.so" \
+              shim/mojotls_shim.c -lssl -lcrypto
+            patchelf --set-rpath '$ORIGIN' "${PREFIX}/lib/libmojotls.so"
+            ;;
+        esac
+
+        mojo precompile -I "${PREFIX}/lib/mojo" src/tls \
+          -o "${PREFIX}/lib/mojo/tls.mojoc"
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - mojo-compiler ${{ mojo_version }}
+    - if: linux
+      then: patchelf
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - openssl ${{ openssl_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - openssl ${{ openssl_version }}
+
+tests:
+  - requirements:
+      run:
+        - if: linux
+          then: binutils
+    script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/tls.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/tls.mojopkg"
+
+          case "$(uname -s)" in
+            Darwin)
+              SHIM="${PREFIX}/lib/libmojotls.dylib"
+              test -f "${SHIM}"
+              RPATHS="$(otool -l "${SHIM}" | awk \
+                '$1 == "cmd" && $2 == "LC_RPATH" { getline; getline; print $2 }')"
+              test "${RPATHS}" = '@loader_path'
+              otool -D "${SHIM}" | grep -F '@rpath/libmojotls.dylib'
+              otool -L "${SHIM}" | grep -F '@rpath/libssl.3.dylib'
+              otool -L "${SHIM}" | grep -F '@rpath/libcrypto.3.dylib'
+              ;;
+            *)
+              SHIM="${PREFIX}/lib/libmojotls.so"
+              test -f "${SHIM}"
+              readelf -d "${SHIM}" | \
+                grep -E '\((RPATH|RUNPATH)\).*\[\$ORIGIN\]$'
+              readelf -d "${SHIM}" | grep -F '(SONAME)' | grep -F 'libmojotls.so'
+              readelf -d "${SHIM}" | grep -F '(NEEDED)' | grep -F 'libssl.so.3'
+              readelf -d "${SHIM}" | grep -F '(NEEDED)' | grep -F 'libcrypto.so.3'
+              ;;
+          esac
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          openssl req -x509 -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=mojo-tls package CA' \
+            -addext 'basicConstraints=critical,CA:TRUE' \
+            -addext 'keyUsage=critical,keyCertSign,cRLSign' \
+            -keyout "${WORK}/ca.key" -out "${WORK}/ca.pem" -days 1 \
+            >/dev/null 2>&1
+          openssl req -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=localhost' \
+            -keyout "${WORK}/server.key" -out "${WORK}/server.csr" \
+            >/dev/null 2>&1
+          printf '%s\n' \
+            'subjectAltName=DNS:localhost,IP:127.0.0.1,URI:spiffe://example.test/package-server,email:server@example.test' \
+            'keyUsage=critical,digitalSignature,keyEncipherment' \
+            'extendedKeyUsage=serverAuth' 'basicConstraints=CA:FALSE' \
+            > "${WORK}/server.ext"
+          openssl x509 -req -sha256 -in "${WORK}/server.csr" \
+            -CA "${WORK}/ca.pem" -CAkey "${WORK}/ca.key" -CAcreateserial \
+            -extfile "${WORK}/server.ext" \
+            -out "${WORK}/server.pem" -days 1 >/dev/null 2>&1
+          openssl req -newkey rsa:2048 -sha256 -nodes \
+            -subj '/CN=mojo-tls package client' \
+            -keyout "${WORK}/client.key" -out "${WORK}/client.csr" \
+            >/dev/null 2>&1
+          printf '%s\n' \
+            'subjectAltName=DNS:client.example.test,IP:192.0.2.45,URI:spiffe://example.test/package-client,email:client@example.test' \
+            'keyUsage=critical,digitalSignature,keyEncipherment' \
+            'extendedKeyUsage=clientAuth' 'basicConstraints=CA:FALSE' \
+            > "${WORK}/client.ext"
+          openssl x509 -req -sha256 -in "${WORK}/client.csr" \
+            -CA "${WORK}/ca.pem" -CAkey "${WORK}/ca.key" -CAcreateserial \
+            -extfile "${WORK}/client.ext" \
+            -out "${WORK}/client.pem" -days 1 >/dev/null 2>&1
+
+          SMOKE="${PWD}/tests/package_smoke.mojo"
+          MOJO="${PREFIX}/bin/mojo"
+          test -x "${MOJO}"
+          cd "${WORK}"
+          export CONDA_PREFIX="${PREFIX}"
+          export MODULAR_HOME="${PREFIX}/share/max"
+          export PATH="${PREFIX}/bin:${PATH}"
+          unset MOJO_TLS_SHIM
+          test -z "${MOJO_TLS_SHIM:-}"
+          if [ "$(uname -s)" = Linux ]; then
+            "${MOJO}" build --emit object "${SMOKE}" -o package_smoke.o
+            test -s package_smoke.o
+            "${MOJO}" run "${SMOKE}" ca.pem server.pem server.key \
+              client.pem client.key
+          else
+            "${MOJO}" build "${SMOKE}" -o package_smoke
+            ./package_smoke ca.pem server.pem server.key client.pem client.key
+          fi
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/mojo-tls
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Strict TLS 1.2 and TLS 1.3 streams for Mojo
+  repository: https://github.com/nsalerni/mojo-tls
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: mojo-tls

--- a/recipes/mojo-tls/tests/package_smoke.mojo
+++ b/recipes/mojo-tls/tests/package_smoke.mojo
@@ -1,0 +1,117 @@
+from std.ffi import c_int, external_call
+from std.sys import argv
+from std.testing import assert_equal, assert_true
+
+from net import TCPListener, TCPStream
+from tls import PeerCertificate, SubjectAlternativeNames, TLSContext
+
+
+def run_server(
+    cert: String, key: String, client_ca: String
+) raises -> Tuple[UInt16, c_int]:
+    var listener = TCPListener("127.0.0.1", 0)
+    var port = listener.local_port
+    var pid = external_call["fork", c_int]()
+    if pid == 0:
+        try:
+            var context = TLSContext.server(
+                cert,
+                key,
+                client_ca_file=client_ca,
+                require_client_cert=True,
+                alpn=["h2"],
+            )
+            var tcp = listener.accept()
+            var stream = context.accept(tcp^)
+            var peer = stream.peer_certificate()
+            if not peer:
+                raise Error("installed server did not receive client identity")
+            var identity: PeerCertificate = peer.value().copy()
+            if not identity.verified or len(identity.leaf_der) == 0:
+                raise Error("installed server did not verify client identity")
+            if identity.matched_name != "":
+                raise Error("server client identity had a matched hostname")
+            var client_names: SubjectAlternativeNames = (
+                identity.subject_alt_names.copy()
+            )
+            if (
+                len(client_names.dns_names) != 1
+                or client_names.dns_names[0] != "client.example.test"
+                or client_names.uri_names[0]
+                != "spiffe://example.test/package-client"
+                or client_names.email_addresses[0] != "client@example.test"
+                or client_names.ip_addresses[0] != "192.0.2.45"
+            ):
+                raise Error("installed server copied wrong client names")
+            var request = stream.read_exact(4)
+            stream.write_all(Span(request))
+            stream.close()
+        except:
+            external_call["_exit", NoneType](c_int(1))
+        external_call["_exit", NoneType](c_int(0))
+    listener.close()
+    return (port, pid)
+
+
+def main() raises:
+    var args = argv()
+    assert_equal(
+        len(args),
+        6,
+        "expected CA, server identity, and client identity paths",
+    )
+
+    var compatibility_der = List[Byte](length=1, fill=0x30)
+    var compatibility = PeerCertificate(
+        compatibility_der^, False, String("legacy.example")
+    )
+    assert_equal(compatibility.matched_name, "legacy.example")
+    assert_equal(len(compatibility.subject_alt_names.dns_names), 0)
+
+    var server = run_server(
+        String(args[2]), String(args[3]), String(args[1])
+    )
+    var context = TLSContext.client(
+        ca_file=String(args[1]),
+        cert_chain_pem=String(args[4]),
+        key_pem=String(args[5]),
+        alpn=["h2"],
+    )
+    var tcp = TCPStream.connect("127.0.0.1", server[0])
+    var stream = context.connect(tcp^, "localhost")
+    var peer = stream.peer_certificate()
+    if not peer:
+        raise Error("installed client did not receive server identity")
+    var identity: PeerCertificate = peer.value().copy()
+    assert_true(identity.verified)
+    assert_true(len(identity.leaf_der) > 0)
+    assert_equal(identity.matched_name, "localhost")
+    assert_equal(identity.subject_alt_names.dns_names[0], "localhost")
+    assert_equal(
+        identity.subject_alt_names.uri_names[0],
+        "spiffe://example.test/package-server",
+    )
+    assert_equal(
+        identity.subject_alt_names.email_addresses[0],
+        "server@example.test",
+    )
+    assert_equal(identity.subject_alt_names.ip_addresses[0], "127.0.0.1")
+
+    assert_true(stream.version().startswith("TLSv1."), stream.version())
+    assert_equal(stream.negotiated_alpn(), "h2")
+    stream.write_all("ping".as_bytes())
+    assert_equal(String(from_utf8=stream.read_exact(4)), "ping")
+    stream.close()
+    assert_true(len(identity.leaf_der) > 0)
+    assert_equal(
+        identity.subject_alt_names.uri_names[0],
+        "spiffe://example.test/package-server",
+    )
+
+    var status = c_int(0)
+    var waited = external_call["waitpid", c_int](
+        server[1], Pointer(to=status), c_int(0)
+    )
+    assert_equal(waited, server[1], "waitpid failed")
+    assert_equal(status, 0, "TLS server failed")
+    print("installed mojo-tls package handshake passed")


### PR DESCRIPTION
Adds `mojo-tls` 0.3.2, TLS 1.2/1.3 streams on top of `mojo-net`.

This is a follow-up to https://github.com/modular/modular-community/pull/317. That PR bundled five packages plus build-order changes; this one adds only `mojo-tls`.

`mojo-net` 0.2.6 is now on the channel (https://prefix.dev/channels/modular-community/packages/mojo-net) for linux-64, linux-aarch64, and osx-arm64, so this recipe can resolve its sibling dep.

| | |
| --- | --- |
| Version | 0.3.2 |
| Source | https://github.com/nsalerni/mojo-tls/tree/v0.3.2 |
| Pin | `f79b8ae0013b9f1011694c8d93a0317fc22ebe28` |
| Artifacts | `tls.mojoc` plus `libmojotls` OpenSSL shim |
| Sibling deps | `mojo-net >=0.2.5,<0.3.0` (0.2.6 published) |

**Checklist**
- [x] Recipe specifies compatible MAX/Mojo (`mojo-compiler >=1.0.0,<1.1.0`)
- [x] License file is packaged (`license_file: LICENSE`)
- [x] Build number set to `0` (new package)
- [ ] N/A: bump build number

Please add the **OK to test** label. PR CI only runs when that label is present.