### PR TITLE
Add mojo-http2 0.2.8

### DIFF
--- a/recipes/mojo-http2/recipe.yaml
+++ b/recipes/mojo-http2/recipe.yaml
@@ -1,0 +1,82 @@
+context:
+  version: "0.2.8"
+  mojo_version: ">=1.0.0,<1.1.0"
+  mojo_net_version: ">=0.2.4,<0.3.0"
+  mojo_tls_version: ">=0.2.0,<0.4.0"
+
+package:
+  name: mojo-http2
+  version: ${{ version }}
+
+source:
+  - git: https://github.com/nsalerni/mojo-http2.git
+    rev: c8038269dfef544a7325a971857803b3bfc5b725
+
+build:
+  number: 0
+  script:
+    interpreter: bash
+    content:
+      - |
+        set -euo pipefail
+        mkdir -p "${PREFIX}/lib/mojo"
+        mojo precompile src/hpack \
+          -o "${PREFIX}/lib/mojo/hpack.mojoc"
+        mojo precompile -I "${PREFIX}/lib/mojo" src/h2 \
+          -o "${PREFIX}/lib/mojo/h2.mojoc"
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - mojo-tls ${{ mojo_tls_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+    - mojo-net ${{ mojo_net_version }}
+    - mojo-tls ${{ mojo_tls_version }}
+
+tests:
+  - script:
+      interpreter: bash
+      content:
+        - |
+          set -euo pipefail
+          test -f "${PREFIX}/lib/mojo/hpack.mojoc"
+          test -f "${PREFIX}/lib/mojo/h2.mojoc"
+          test ! -e "${PREFIX}/lib/mojo/hpack.mojopkg"
+          test ! -e "${PREFIX}/lib/mojo/h2.mojopkg"
+
+          WORK="$(mktemp -d)"
+          trap 'rm -rf "${WORK}"' EXIT
+          SMOKE="${PWD}/tests/package_smoke.mojo"
+          MOJO="${PREFIX}/bin/mojo"
+          test -x "${MOJO}"
+          cd "${WORK}"
+          export CONDA_PREFIX="${PREFIX}"
+          export MODULAR_HOME="${PREFIX}/share/max"
+          export PATH="${PREFIX}/bin:${PATH}"
+          if [ "$(uname -s)" = Linux ]; then
+            "${MOJO}" build --emit object "${SMOKE}" -o package_smoke.o
+            test -s package_smoke.o
+            "${MOJO}" run "${SMOKE}"
+          else
+            "${MOJO}" build "${SMOKE}" -o package_smoke
+            ./package_smoke
+          fi
+    files:
+      recipe:
+        - tests/package_smoke.mojo
+
+about:
+  homepage: https://github.com/nsalerni/mojo-http2
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: HPACK and HTTP/2 with h2c and TLS transports for Mojo
+  repository: https://github.com/nsalerni/mojo-http2
+
+extra:
+  maintainers:
+    - nsalerni
+  project_name: mojo-http2

--- a/recipes/mojo-http2/tests/package_smoke.mojo
+++ b/recipes/mojo-http2/tests/package_smoke.mojo
@@ -1,0 +1,30 @@
+from std.testing import assert_equal
+
+from h2 import H2_ALPN, FrameHeader
+from hpack import Decoder, HeaderField
+
+
+def main() raises:
+    var header = FrameHeader(
+        length=1024, frame_type=0x1, flags=0x5, stream_id=7
+    )
+    var wire = List[Byte]()
+    header.serialize(wire)
+    var parsed = FrameHeader.parse(Span(wire))
+    assert_equal(parsed.length, 1024)
+    assert_equal(parsed.frame_type, 0x1)
+    assert_equal(parsed.flags, 0x5)
+    assert_equal(parsed.stream_id, 7)
+
+    var block = List[Byte]()
+    block.append(0x82)
+    block.append(0x86)
+    block.append(0x84)
+    var decoder = Decoder()
+    var fields = decoder.decode(Span(block))
+    assert_equal(len(fields), 3)
+    assert_equal(fields[0], HeaderField(name=":method", value="GET"))
+    assert_equal(fields[1], HeaderField(name=":scheme", value="http"))
+    assert_equal(fields[2], HeaderField(name=":path", value="/"))
+    assert_equal(String(H2_ALPN), "h2")
+    print("installed mojo-http2 package smoke test passed")


### PR DESCRIPTION
Adds `mojo-http2` 0.2.8, HPACK and HTTP/2 with h2c and TLS transports.

This is a follow-up to https://github.com/modular/modular-community/pull/317. That PR bundled five packages plus build-order changes; this one adds only `mojo-http2`.

`mojo-net` 0.2.6 and `mojo-tls` 0.3.2 are now on the channel for linux-64, linux-aarch64, and osx-arm64, so this recipe can resolve its sibling deps.

| | |
| --- | --- |
| Version | 0.2.8 |
| Source | https://github.com/nsalerni/mojo-http2/tree/v0.2.8 |
| Pin | `c8038269dfef544a7325a971857803b3bfc5b725` |
| Artifacts | `hpack.mojoc` and `h2.mojoc` via `mojo precompile` |
| Sibling deps | `mojo-net >=0.2.4,<0.3.0` (0.2.6 published), `mojo-tls >=0.2.0,<0.4.0` (0.3.2 published) |

**Checklist**
- [x] Recipe specifies compatible MAX/Mojo (`mojo-compiler >=1.0.0,<1.1.0`)
- [x] License file is packaged (`license_file: LICENSE`)
- [x] Build number set to `0` (new package)
- [ ] N/A: bump build number

Please add the **OK to test** label. PR CI only runs when that label is present.