### PR TITLE
Add knap, a byte level BPE tokenizer in pure Mojo

### DIFF
--- a/recipes/knap/recipe.yaml
+++ b/recipes/knap/recipe.yaml
@@ -111,8 +111,17 @@ tests:
         test -f "${PREFIX}/share/bash-completion/completions/knap"
         test -f "${PREFIX}/share/zsh/site-functions/_knap"
         test -f "${PREFIX}/share/fish/vendor_completions.d/knap.fish"
-        "${PREFIX}/bin/knap" version
-        mojo run -I "${PREFIX}/lib/mojo" smoke.mojo
+        # The version the binary reports must be the version the package
+        # claims. Printing it proves only that the binary runs; a package
+        # built from the wrong revision would pass that and fail this.
+        test "$("${PREFIX}/bin/knap" version)" = "${{ version }}"
+
+        # No -I here, deliberately. The build installs into
+        # ${PREFIX}/lib/mojo precisely so the compiler finds the package
+        # without one, and a test that passes the flag would still pass if
+        # that promise were broken. This line is what makes the claim above
+        # the build script an assertion rather than a comment.
+        mojo run smoke.mojo
     files:
       recipe:
         - smoke.mojo

--- a/recipes/knap/recipe.yaml
+++ b/recipes/knap/recipe.yaml
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright 2026 Olaf Yunus Laitinen Imanov
+#
+# Conda recipe for Knap, a byte level BPE tokenizer written in pure Mojo.
+#
+#     https://github.com/olaflaitinen/knap
+#
+# The artefact is a precompiled Mojo package plus a command line tool. The
+# compiler's own documentation is careful to say a precompiled package is
+# tied to the exact compiler version that produced it, which is why the
+# compiler is pinned exactly in the run requirements rather than given a
+# range. A consumer on a different toolchain gets a solver error, which is
+# far better than a link error deep in their build. That is a deliberate
+# deviation from pin_compatible and the reasoning is here rather than in a
+# pull request comment, so it survives.
+#
+# This recipe is maintained in the Knap repository at
+# conda.recipe/recipe.yaml and copied here. scripts/check_recipe.py there
+# checks, on every push, that the declared version agrees with CITATION.cff,
+# that the compiler pin agrees with pixi.toml and pyproject.toml, that
+# source.rev is a commit in that repository, and that every path the build
+# script reads exists at that commit.
+#
+# Build it:
+#
+#     rattler-build build \
+#       --recipe recipes/knap/recipe.yaml \
+#       -c conda-forge \
+#       -c https://conda.modular.com/max \
+#       -c https://repo.prefix.dev/modular-community
+
+schema_version: 1
+
+context:
+  version: "1.0.0"
+  mojo_version: "1.0.0"
+
+package:
+  name: knap
+  version: ${{ version }}
+
+# A git source at a full commit SHA rather than a local path. Two reasons,
+# and the second is the one that matters. A path source cannot be built by
+# anyone but the author, so the modular-community repository, which holds
+# only the recipe, could not build it at all. And a SHA is reproducible in a
+# way a branch or a tag is not: a tag can be moved, a branch always is.
+#
+# The SHA below is the v1.0.0 release commit of the Knap repository. It is
+# updated as part of preparing a release, and Knap's own recipe gate
+# refuses a value that is not a commit there.
+source:
+  - git: https://github.com/olaflaitinen/knap.git
+    rev: e83f0ea34fb6d586551b7f9df226006d78dc1436
+
+build:
+  number: 0
+  # Noarch is wrong here even though a precompiled Mojo package contains no
+  # elaborated code. The package is tied to a compiler version rather than to
+  # an architecture, and conda has no way to express that, so it is built per
+  # platform and pinned to the compiler instead.
+  script:
+    interpreter: bash
+    content: |
+      set -euo pipefail
+
+      # Into $PREFIX/lib/mojo, which is the path that makes the package
+      # discoverable by the compiler without a -I flag.
+      mkdir -p "${PREFIX}/lib/mojo"
+      mojo precompile src/knap -o "${PREFIX}/lib/mojo/knap.mojoc"
+
+      # The command line tool, so that installing the package gives a person
+      # a working `knap` command rather than a library they have to write a
+      # program against. Counting tokens is the most common thing anyone
+      # does with a tokenizer, and it should not require a toolchain.
+      mkdir -p "${PREFIX}/bin"
+      mojo build -I src -I cli -o "${PREFIX}/bin/knap" cli/main.mojo
+
+      # Shell completions, in the directories each shell searches. A tool
+      # that installs a binary and no completions is a tool people type the
+      # long way for years.
+      mkdir -p "${PREFIX}/share/bash-completion/completions"
+      cp cli/completions/knap.bash \
+        "${PREFIX}/share/bash-completion/completions/knap"
+      mkdir -p "${PREFIX}/share/zsh/site-functions"
+      cp cli/completions/_knap "${PREFIX}/share/zsh/site-functions/_knap"
+      mkdir -p "${PREFIX}/share/fish/vendor_completions.d"
+      cp cli/completions/knap.fish \
+        "${PREFIX}/share/fish/vendor_completions.d/knap.fish"
+
+requirements:
+  build:
+    - mojo-compiler ==${{ mojo_version }}
+  host:
+    - mojo-compiler ==${{ mojo_version }}
+  # pin_compatible would be the idiomatic choice here and it is deliberately
+  # not used. It derives a range from whatever version resolved at build
+  # time, and a range is exactly what a precompiled Mojo artefact cannot
+  # honour: the compiler's own documentation says a .mojoc file may not be
+  # compatible with another compiler version, and the ABI is explicitly not
+  # stable. An exact pin turns that into a solver error at install time.
+  run:
+    - mojo-compiler ==${{ mojo_version }}
+
+tests:
+  - script:
+      interpreter: bash
+      content: |
+        set -euo pipefail
+        test -f "${PREFIX}/lib/mojo/knap.mojoc"
+        test -x "${PREFIX}/bin/knap"
+        test -f "${PREFIX}/share/bash-completion/completions/knap"
+        test -f "${PREFIX}/share/zsh/site-functions/_knap"
+        test -f "${PREFIX}/share/fish/vendor_completions.d/knap.fish"
+        "${PREFIX}/bin/knap" version
+        mojo run -I "${PREFIX}/lib/mojo" smoke.mojo
+    files:
+      recipe:
+        - smoke.mojo
+
+about:
+  homepage: https://github.com/olaflaitinen/knap
+  repository: https://github.com/olaflaitinen/knap.git
+  documentation: https://github.com/olaflaitinen/knap/blob/main/README.md
+  license: EUPL-1.2
+  license_file: LICENSE
+  summary: A byte level BPE tokenizer written in pure Mojo, with no Python interpreter at run time.
+  description: |
+    Knap is a byte level Byte Pair Encoding tokenizer written in pure Mojo,
+    verified to produce byte identical output to tiktoken. All seven
+    tiktoken encodings are supported and each was checked against tiktoken
+    itself: 191762320 tokens over a 110 MB corpus, every token id in every
+    encoding, and tens of millions of fuzzed inputs.
+
+    Installing it gives both a Mojo library and a `knap` command for
+    counting, encoding, and decoding from a shell. Vocabularies are not
+    bundled and are fetched separately; `knap help` says where the tool
+    looks for them.
+
+    Correctness is the product. Knap is faster than tiktoken on three of the
+    four distinct encode behaviours on the published machine and slower than
+    rs-bpe everywhere rs-bpe runs, and its benchmarks publish the cases
+    where the alternatives win.
+
+extra:
+  maintainers:
+    - olaflaitinen

--- a/recipes/knap/smoke.mojo
+++ b/recipes/knap/smoke.mojo
@@ -1,0 +1,65 @@
+# =============================================================================
+# Project     : Knap, a pure Mojo byte level BPE tokenizer
+# File        : conda.recipe/smoke.mojo
+# Purpose     : Package acceptance test. Imports Knap from the installed
+#               conda package and decodes one token, with no source tree.
+# Stage       : Distribution. See docs/PACKAGING.md
+# Depends on  : knap.flat_vocab, resolved from $PREFIX/lib/mojo
+# Invariants  : Imports nothing that needs a vocabulary file, so the test
+#               passes or fails on the package rather than on a download.
+# -----------------------------------------------------------------------------
+# Author      : Olaf Yunus Laitinen Imanov <yunus.imanov@metropolia.fi>
+# ORCID       : 0009-0006-5184-0810
+# Affiliation : School of Information and Communication Technology,
+#               Metropolia University of Applied Sciences
+# -----------------------------------------------------------------------------
+# SPDX-License-Identifier: EUPL-1.2
+# Copyright 2026 Olaf Yunus Laitinen Imanov
+# =============================================================================
+"""Package acceptance test for the Knap conda package.
+
+A package that builds but cannot be imported without the source tree is not
+a package, and nothing in the build itself would notice. This program is run
+by the recipe's test section against the installed artefact only, with
+`-I $PREFIX/lib/mojo` and no path into the repository.
+
+It is deliberately small. It builds a two byte vocabulary by hand and
+decodes one token, which exercises the import path, the precompiled package,
+and one real code path, and needs no vocabulary download to do it. A larger
+test here would be testing Knap, which the suite already does, rather than
+testing the package.
+
+    mojo run -I "$PREFIX/lib/mojo" smoke.mojo
+"""
+
+from knap.flat_vocab import FlatVocab
+
+
+def main() raises:
+    """Decode one token from a hand built vocabulary.
+
+    Raises:
+        Error: if the package cannot be imported, or if the decode returns
+            anything other than the two bytes that went in.
+    """
+    var data = List[UInt8]()
+    data.append(UInt8(72))  # H
+    data.append(UInt8(105))  # i
+
+    var offsets: List[Int] = [0]
+    var lengths: List[Int] = [2]
+    var vocabulary = FlatVocab(data^, offsets^, lengths^)
+
+    var decoded = vocabulary.decode([0])
+    if decoded != String("Hi"):
+        raise Error(
+            String(
+                t"knap package smoke test: decoded '{decoded}', expected 'Hi'"
+            )
+        )
+    print("knap package smoke test: import and decode both work")
+
+
+# =============================================================================
+# End of file: conda.recipe/smoke.mojo
+# =============================================================================


### PR DESCRIPTION
Adds `recipes/knap/`, a recipe and its test file for **Knap**, a byte level BPE tokenizer written in pure Mojo.

- Repository: <https://github.com/olaflaitinen/knap>
- Release: <https://github.com/olaflaitinen/knap/releases/tag/v1.0.0>
- Licence: EUPL-1.2
- Maintainer: @olaflaitinen

## What the package contains

| Path | What it is |
| --- | --- |
| `$PREFIX/lib/mojo/knap.mojoc` | The precompiled library, importable with no include flag |
| `$PREFIX/bin/knap` | A command line tool, so installing gives a working `knap count` rather than a library you have to write a program against |
| `$PREFIX/share/{bash-completion,zsh/site-functions,fish/vendor_completions.d}/` | Completions for the three shells |

No vocabulary is bundled. Vocabulary files are third party data under their own terms, and bundling them would attach a licence question to this package that fetching them does not.

## What it does

All seven `tiktoken` encodings: `cl100k_base`, `o200k_base`, `o200k_harmony`, `p50k_base`, `p50k_edit`, `r50k_base` and `gpt2`. Byte identical with `tiktoken` over a 110 MB corpus, 191762320 tokens, plus 20 million differentially fuzzed inputs with zero divergences. No Python interpreter at run time.

## Verification

Built locally with `rattler-build` from this recipe at this path, and the test section run against the installed artefact: `knap-1.0.0-hb0f4dca_0.conda`, 341 KiB, completions present, `knap version` printing `1.0.0`, and `mojo run -I $PREFIX/lib/mojo smoke.mojo` importing the package and decoding through it.

## One deliberate deviation, and why

The run requirement is `mojo-compiler ==1.0.0` rather than `pin_compatible('mojo-compiler')`.

`pin_compatible` derives a range from whatever resolved at build time, and a range is the one thing a precompiled Mojo artefact cannot honour: the compiler's documentation says a `.mojoc` file may not be compatible with another compiler version, and the ABI is explicitly not stable. An exact pin turns that into a solver error at install time instead of a link error deep in a consumer's build. The reasoning is written into the recipe rather than left in this thread, so it survives.

Happy to change it if the channel prefers consistency here.

## Maintenance

The recipe is maintained in the Knap repository at `conda.recipe/recipe.yaml` and copied here. A gate there checks on every push that the declared version agrees with `CITATION.cff`, that the compiler pin agrees with `pixi.toml` and `pyproject.toml`, that `source.rev` is a commit in that repository, and that every path the build script reads exists at that commit. That last check was added after the recipe pinned a commit older than its own build script and the package build died on a file that had been added months later.
