### PR TITLE
flare-routegen version 0.1.0

### DIFF
--- a/recipes/flare-routegen/recipe.yaml
+++ b/recipes/flare-routegen/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: flare-routegen
+  version: ${{ version }}
+
+
+source:
+  - git: https://github.com/joeressler/flare-routegen.git
+    rev: 531933edcbef7b3f465abbbbd051b69e19920062
+build:
+  number: 0
+  skip:
+    - osx
+    - win
+  script:
+    - mkdir -p ${{ PREFIX }}/bin
+    - mojo build -I src src/main.mojo -o ${{ PREFIX }}/bin/flare-routegen
+
+requirements:
+  host:
+    - mojo-compiler =1.0.0
+  build:
+    - mojo-compiler =1.0.0
+    - gxx >=13
+    - sysroot_linux-64 >=2.34
+  run:
+    - ${{ pin_compatible('mojo-compiler') }}
+
+tests:
+  - script:
+      - flare-routegen --version
+      - flare-routegen --help
+
+about:
+  homepage: https://github.com/joeressler/flare-routegen
+  repository: https://github.com/joeressler/flare-routegen
+  license: MIT
+  license_file: LICENSE
+  summary: Generate Flare route registrations from structured Mojo comment directives.
+
+extra:
+  maintainers:
+    - joeressler
+  project_name:
+    - flare-routegen


### PR DESCRIPTION
flare-routegen is a Mojo CLI that turns # @flare.route faux-macro comments into deterministic Flare ComptimeRoute tables, so apps can keep valid Mojo source while committing generated glue. It provides a Flare-specific generate/check/list tool without depending on a Flare conda package, apps still need to bring their own Flare to compile the output. This is in lieu of custom decorators in Mojo 1.0 and out of a desire for the same beauty of Flask decorators in Mojo, albeit toned down. I'm still a beginner to Mojo but I'd love some contributions or advice surrounding some of the more advanced generator sections!

**Checklist**
- [x] My `recipe.yaml` file specifies which version(s) of MAX is compatible with my project (see [here](https://github.com/modular/modular-community/blob/main/recipes/endia/recipe.yaml) for an example). If not, my package is compatible with both 24.5 and 24.6.
- [x] License file is packaged (see [here](https://github.com/modular/modular-community/blob/dbe0200598733fea411ee2246507705e8ea07a32/recipes/hue/recipe.yaml#L33-L40) for an example).
- [x] Set the build number to `0` (for new packages, or if the version changed).
- [x] Bumped the build number (if the version is unchanged).
